### PR TITLE
BE-Set Up spectacular

### DIFF
--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -40,8 +40,8 @@ INSTALLED_APPS = [
     "corsheaders", #cors
     "rest_framework", #drf
     "rest_framework_simplejwt.token_blacklist", #authentification
-    "drf_spectacular", #spectucular
     "SMMapp", #ourapp
+    "drf_spectacular", #spectacular
 ]
 
 MIDDLEWARE = [
@@ -134,6 +134,13 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
-    # YOUR SETTINGS
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Swim Meet Management API',
+    'DESCRIPTION': 'An API for managing swim meets, participants, and results.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}
+

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -15,11 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     #spectacular endpoints
     path('schema/', SpectacularAPIView.as_view(), name='schema'),
     path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger'),
+    path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -15,7 +15,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    #spectacular endpoints
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger'),
 ]


### PR DESCRIPTION
This PR resolves Issue #1 

### Implementation

1. **backend/project/settings.py**
Introduced the necessary dictionary for Spectacular settings. This includes the project's name, a description and version.

Set 'SERVE_INCLUDE_SCHEMA': False to exclude the API documentation from the API responses. This decision was made as the link to the schema is already included below the API title.

2. **backend/project/urls.py**
Added the schema endpoint for Spectacular and the Swagger view.

### Swagger view

<img width="386" alt="image" src="https://github.com/MarisiaS/SMM/assets/95152310/7eb51c27-c58e-4c49-8469-2dfc85759fa5">
