### PR TITLE
BE- Improve Site implementation

### DIFF
--- a/backend/api/serializers/SiteSerializer.py
+++ b/backend/api/serializers/SiteSerializer.py
@@ -8,3 +8,13 @@ class SiteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Site
         fields = ('id', 'name', 'num_lanes', 'pool_len', 'len_unit')
+
+    # Validate that name is unique, if not raise a Validation Error
+    def validate_name(self, value):
+        if self.instance and self.instance.name == value:
+            return value  # No change, no validation needed for the same name
+
+        if Site.objects.filter(name=value).exists():
+            raise serializers.ValidationError('Duplicate value, it already exists.')
+
+        return value


### PR DESCRIPTION
This PR addresses issue #44

## **Implementation**

1. **backend/api/serializers/SiteSerializer.py*
Add the serializer method `validate_name` to check if the site name is unique. It throws a Validation Error if there is an existing site with the same name.

2. **backend/api/views/SiteView.py**
Added the patch method to the http_method_names in the site view.
In the list method, used the LimitOffsetPagination (setup in the settings) to return the serialized data paginated.

## **Swagger**

### Patch endpoint:
The patch endpoint for Site is now available in  Swagger:
<img width="972" alt="Screenshot 2024-02-12 at 11 31 19 AM" src="https://github.com/MarisiaS/SMM/assets/102187795/053028aa-15c5-4b49-86fc-de13f1abccd4">

I updated the information for a site using this endpoint and confirmed the new site information is saved.


### List endpoint:
The list(Get) endpoint is including the pagination information in the response:
Before 

<img width="967" alt="Screenshot 2024-02-12 at 11 06 20 AM" src="https://github.com/MarisiaS/SMM/assets/102187795/5c8be545-0e1a-461c-aebb-06a6e5f0e9ab">

After
<img width="1006" alt="Screenshot 2024-02-12 at 11 07 31 AM" src="https://github.com/MarisiaS/SMM/assets/102187795/3ef22cc8-ecf7-44bc-98c7-92c640c5c15a">

### Duplicate site name:
When trying to post or patch a Site using an existing name, the response is now a Bad Request error (400 status code) with the appropriate message:
<img width="969" alt="Screenshot 2024-02-12 at 11 23 46 AM" src="https://github.com/MarisiaS/SMM/assets/102187795/ca8f4665-df9d-4754-983f-de149d6bf3f7">


