### PR TITLE
BE- Add unique and db_collation attributes to School name

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -30,6 +30,6 @@ class Site(models.Model):
     len_unit = models.CharField(max_length=20, choices=Len_unit.choices, default=Len_unit.YARDS)
 
 class School(models.Model):
-    name = models.CharField(max_length=255, null=False, blank=False)
+    name = models.CharField(max_length=255, null=False, blank=False, unique=True, db_collation='case_insensitive')
     open_hour = models.TimeField(null=True, blank=True)
     close_hour = models.TimeField(null=True, blank=True)


### PR DESCRIPTION
This PR fixes issue #46 

## **Implementation**

1. **backend/api/models.py*
For the School model, added the attributes `unique=True `and `db_collation='case_insensitive'` to the name field.

Note that this change didn't generated a new migration since these attributes were previously added in the manual migration  `_0007_add_collation_unique_to_name_school_` but forgot to add them in the model declaration.