### PR TITLE
BE-Generate heats 

### DIFF
--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 from api.CustomField import HeatDurationField
+from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 import math
 
 
@@ -10,7 +11,30 @@ class AthleteSeedSerializer(serializers.Serializer):
     athlete = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
     seed_time = HeatDurationField()
 
-
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            name='Generate heat request body',
+            value={
+                "athletes": [
+                    {
+                        "athlete": 1,
+                        "seed_time": "45.00"
+                    },
+                    {
+                        "athlete": 2,
+                        "seed_time": "26.09"
+                    },
+                    {
+                        "athlete": 3,
+                        "seed_time": "NT"
+                    }
+                ]
+            },
+            request_only=True, 
+            )
+    ]
+)
 class GenerateHeatSerializer(serializers.Serializer):
     athletes = AthleteSeedSerializer(many=True)
 

--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -52,18 +52,18 @@ class GenerateHeatSerializer(serializers.Serializer):
         athletes_sorted = sorted(athletes, key=lambda x: -x['seed_time'])
         num_athletes = len(athletes_sorted)
         current_num_heat = 1
-        num_empty_athletes = (num_lanes - num_athletes%num_lanes) %num_lanes
-        num_empty_athletes_current_heat = math.ceil(num_empty_athletes/2) if num_athletes > num_lanes else num_empty_athletes
+        num_empty_athletes = (num_lanes - num_athletes%num_lanes) % num_lanes
+        num_empty_athletes_current_heat = math.ceil(num_empty_athletes / 2) if num_athletes > num_lanes else num_empty_athletes
         while(athletes_sorted):
-            current_heat_athletes = athletes_sorted[:num_lanes-num_empty_athletes_current_heat]
-            athletes_sorted = athletes_sorted[num_lanes-num_empty_athletes_current_heat:]
+            current_heat_athletes = athletes_sorted[:num_lanes - num_empty_athletes_current_heat]
+            athletes_sorted = athletes_sorted[num_lanes - num_empty_athletes_current_heat:]
             for i in range(num_empty_athletes_current_heat, num_lanes):
                 num_lane = self.calculate_lane_num(i,num_lanes)
                 Heat.objects.create(
                     event=event_instance,
-                    athlete=current_heat_athletes[i-num_empty_athletes_current_heat]["athlete"],
+                    athlete=current_heat_athletes[i - num_empty_athletes_current_heat]["athlete"],
                     lane_num= num_lane,
-                    seed_time=current_heat_athletes[i-num_empty_athletes_current_heat]["seed_time"],
+                    seed_time=current_heat_athletes[i - num_empty_athletes_current_heat]["seed_time"],
                     heat_time=None,
                     num_heat=current_num_heat
                 )
@@ -75,8 +75,8 @@ class GenerateHeatSerializer(serializers.Serializer):
    
     def calculate_lane_num(self, index, num_lanes):
         #Calculates the corresponding lane number for an athlete at a given index on the list of athletes.
-        remainder = index%num_lanes
-        half_lane = math.ceil(num_lanes/2)
+        remainder = index % num_lanes
+        half_lane = math.ceil(num_lanes / 2)
         side = math.pow(-1,remainder)
-        distance_to_half = (num_lanes-remainder)//2
-        return int(half_lane + side*distance_to_half)
+        distance_to_half = (num_lanes - remainder) // 2
+        return int(half_lane + side * distance_to_half)

--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -30,7 +30,7 @@ class GenerateHeatSerializer(serializers.Serializer):
         current_num_heat = 1
         num_empty_athletes = (num_lanes - num_athletes%num_lanes) %num_lanes
         num_empty_athletes_current_heat = math.ceil(num_empty_athletes/2) if num_athletes > num_lanes else num_empty_athletes
-        while(len(athletes_sorted)>0):
+        while(athletes_sorted):
             current_heat_athletes = athletes_sorted[:num_lanes-num_empty_athletes_current_heat]
             athletes_sorted = athletes_sorted[num_lanes-num_empty_athletes_current_heat:]
             for i in range(num_empty_athletes_current_heat, num_lanes):

--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -1,0 +1,61 @@
+from api.models import Athlete, Heat
+from rest_framework import serializers
+from django.db import transaction
+from api.CustomField import HeatDurationField
+import math
+
+
+class AthleteSeedSerializer(serializers.Serializer):
+    athlete_id = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
+    seed_time = HeatDurationField()
+
+
+
+
+class GenerateHeatSerializer(serializers.Serializer):
+    athletes = AthleteSeedSerializer(many=True)
+
+
+    def validate_athletes(self, value):
+        athlete_ids = [athlete['athlete_id'].id for athlete in value]
+        if len(athlete_ids) != len(set(athlete_ids)):
+            raise serializers.ValidationError("Athletes must not be repeated.")
+        return value
+
+
+    @transaction.atomic
+    def create(self, validated_data):
+        num_lanes = self.context['num_lanes']
+        event_instance = self.context['event']
+        athletes = validated_data.pop('athletes', [])
+        athletes_sorted = sorted(athletes, key=lambda x: -x['seed_time'])
+        num_athletes = len(athletes_sorted)
+        current_num_heat = 1
+        num_empty_athletes = (num_lanes - num_athletes%num_lanes) %num_lanes
+        num_empty_athletes_current_heat = math.ceil(num_empty_athletes/2) if num_athletes > num_lanes else num_empty_athletes
+        while(len(athletes_sorted)>0):
+            current_heat_athletes = athletes_sorted[:num_lanes-num_empty_athletes_current_heat]
+            athletes_sorted = athletes_sorted[num_lanes-num_empty_athletes_current_heat:]
+            for i in range(num_empty_athletes_current_heat, num_lanes):
+                num_lane = self.calculate_lane_num(i,num_lanes)
+                Heat.objects.create(
+                    event=event_instance,
+                    athlete=current_heat_athletes[i-num_empty_athletes_current_heat]["athlete_id"],
+                    lane_num= num_lane,
+                    seed_time=current_heat_athletes[i-num_empty_athletes_current_heat]["seed_time"],
+                    heat_time=None,
+                    num_heat=current_num_heat
+                )
+            num_empty_athletes -= num_empty_athletes_current_heat
+            num_empty_athletes_current_heat = num_empty_athletes
+            current_num_heat += 1
+                   
+        return event_instance
+   
+    def calculate_lane_num(self, index, num_lanes):
+        #Calculates the corresponding lane number for an athlete at a given index on the list of athletes.
+        remainder = index%num_lanes
+        half_lane = math.ceil(num_lanes/2)
+        side = math.pow(-1,remainder)
+        distance_to_half = (num_lanes-remainder)//2
+        return int(half_lane + side*distance_to_half)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -13,6 +13,7 @@ from api.views.AthleteView import AthleteViewSet
 from api.views.TimeRecordView import TimeRecordViewSet
 from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
+from api.views.GenerateHeatView import GenerateHeatView
 
 from rest_framework.routers import SimpleRouter
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('meet_schools/<int:meet_id>/', MeetSchoolView.as_view(), name='meet-schools'),
     path('meet_event/<int:meet_id>/', MeetEventView.as_view(), name='events-meet'),
     path('seed_times/<int:event_id>/', AthleteSeedTimeView.as_view(), name='seed_times'),
+    path('event_heat/<int:event_id>/', GenerateHeatView.as_view(), name='heats-event'),
 ]
 
 urlpatterns += router.urls

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -1,31 +1,77 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from api.models import Athlete, TimeRecord, MeetEvent, Group, EventType, SwimMeet
+from api.models import MeetEvent, Heat, Group, Athlete
 from api.serializers.GenerateHeatSerializer import GenerateHeatSerializer
 from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema
+from django.db.models import F, Value, Func, IntegerField
+from django.utils import timezone
 
 
 @extend_schema(tags=['Heat'])
 @extend_schema(request=GenerateHeatSerializer, methods=['POST'])
 class GenerateHeatView(APIView):
     def post(self, request, event_id):
+        #Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+        
+        #The event should not have heats
+        if Heat.objects.filter(event=event_instance).exists():
+            return Response({'error': 'Event already has heats'}, status=status.HTTP_400_BAD_REQUEST)
        
         #Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
         except:
-            return Response({'error': 'Not able to retrive number of lanes'}, status=status.HTTP_404_NOT_FOUND)
-
-
+            return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
+        
+        #Get group_id
+        try:
+            group_instance = event_instance.group
+        except:
+            return Response({'error': 'Not able to retrieve group'}, status=status.HTTP_404_NOT_FOUND)
+        
+        athletes_data = request.data.get('athletes', [])
+        queryset = self.get_queryset(group_instance.id)
+        queryset_athlete_ids = set(queryset.values_list('id', flat=True))
+        request_athlete_ids = {athlete['athlete'] for athlete in athletes_data}
+        if not request_athlete_ids.issubset(queryset_athlete_ids):
+            return Response({'error': 'One or more athletes are not part of the specified group.'}, status=status.HTTP_400_BAD_REQUEST)
+        
        
-        serializer = GenerateHeatSerializer(data=request.data,context={'num_lanes': num_lanes, 'event': event_instance})
+        serializer = GenerateHeatSerializer(data=request.data, context={'num_lanes': num_lanes, 'event': event_instance})
         if serializer.is_valid(raise_exception=True):
             serializer.save()
         return Response({'success': 'Heats generated'}, status=status.HTTP_200_OK)
+    
+
+    def get_queryset(self, group_id):
+        try:
+            group_instance = Group.objects.get(id=group_id)
+        except Group.DoesNotExist:
+            raise ValidationError({'error': "Group does not exist"}, code=status.HTTP_400_BAD_REQUEST)
+        queryset = Athlete.objects.all()
+        queryset = queryset.annotate(
+                age=Func(
+                    Value("year"),
+                    Func(Value(timezone.now().date()), F(
+                        "date_of_birth"), function="age"),
+                    function="date_part",
+                    output_field=IntegerField()))
+        
+        gender = group_instance.gender
+        if gender != 'MX':
+            queryset = queryset.filter(gender=gender)
+        min_age = group_instance.min_age
+        max_age = group_instance.max_age
+        if max_age is not None:
+            queryset = queryset.filter(age__lte=max_age)
+        if min_age is not None:
+            queryset = queryset.filter(age__gte=min_age)
+            
+        return queryset

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -1,0 +1,30 @@
+from rest_framework.response import Response
+from rest_framework import status
+from api.models import Athlete, TimeRecord, MeetEvent, Group, EventType, SwimMeet
+from api.serializers.GenerateHeatSerializer import GenerateHeatSerializer
+from rest_framework.exceptions import ValidationError
+from drf_spectacular.utils import extend_schema
+
+
+@extend_schema(tags=['Heat'])
+@extend_schema(request=GenerateHeatSerializer, methods=['POST'])
+class GenerateHeatView(APIView):
+    def post(self, request, event_id):
+        try:
+            event_instance = MeetEvent.objects.get(id=event_id)
+        except MeetEvent.DoesNotExist:
+            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+       
+        #Get num_lanes
+        try:
+            swim_meet_instance = event_instance.swim_meet
+            num_lanes = swim_meet_instance.site.num_lanes
+        except:
+            return Response({'error': 'Not able to retrive number of lanes'}, status=status.HTTP_404_NOT_FOUND)
+
+
+       
+        serializer = GenerateHeatSerializer(data=request.data,context={'num_lanes': num_lanes, 'event': event_instance})
+        if serializer.is_valid(raise_exception=True):
+            serializer.save()
+        return Response({'success': 'Heats generated'}, status=status.HTTP_200_OK)

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -30,7 +30,8 @@ class GenerateHeatView(APIView):
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
         
-        #Get group_id
+        #Get group_id 
+        # TODO: Mover despues del is_valid()
         try:
             group_instance = event_instance.group
         except:
@@ -46,9 +47,11 @@ class GenerateHeatView(APIView):
        
         serializer = GenerateHeatSerializer(data=request.data, context={'num_lanes': num_lanes, 'event': event_instance})
         if serializer.is_valid(raise_exception=True):
+
             serializer.save()
         return Response({'success': 'Heats generated'}, status=status.HTTP_200_OK)
     
+    #TODO: Delete method
 
     def get_queryset(self, group_id):
         try:

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -1,3 +1,4 @@
+from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from api.models import Athlete, TimeRecord, MeetEvent, Group, EventType, SwimMeet

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -1,10 +1,13 @@
 from rest_framework.views import APIView
+from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
 from api.models import MeetEvent, Heat, Group, Athlete
 from api.serializers.GenerateHeatSerializer import GenerateHeatSerializer
 from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import IsAuthenticated
+from django.db import transaction
 from django.db.models import F, Value, Func, IntegerField
 from django.utils import timezone
 
@@ -30,28 +33,39 @@ class GenerateHeatView(APIView):
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
         
-        #Get group_id 
-        # TODO: Mover despues del is_valid()
+        #Get group_id
         try:
             group_instance = event_instance.group
         except:
             return Response({'error': 'Not able to retrieve group'}, status=status.HTTP_404_NOT_FOUND)
         
-        athletes_data = request.data.get('athletes', [])
-        queryset = self.get_queryset(group_instance.id)
-        queryset_athlete_ids = set(queryset.values_list('id', flat=True))
-        request_athlete_ids = {athlete['athlete'] for athlete in athletes_data}
-        if not request_athlete_ids.issubset(queryset_athlete_ids):
-            return Response({'error': 'One or more athletes are not part of the specified group.'}, status=status.HTTP_400_BAD_REQUEST)
-        
        
         serializer = GenerateHeatSerializer(data=request.data, context={'num_lanes': num_lanes, 'event': event_instance})
         if serializer.is_valid(raise_exception=True):
-
+            #Before saving, check that the given athletes are part of the event group
+            athletes_data = request.data.get('athletes', [])
+            queryset = self.get_queryset(group_instance.id)
+            queryset_athlete_ids = set(queryset.values_list('id', flat=True))
+            request_athlete_ids = {athlete['athlete'] for athlete in athletes_data}
+            if not request_athlete_ids.issubset(queryset_athlete_ids):
+                return Response({'error': 'One or more athletes are not part of the specified group for the event.'}, status=status.HTTP_400_BAD_REQUEST)
             serializer.save()
         return Response({'success': 'Heats generated'}, status=status.HTTP_200_OK)
     
-    #TODO: Delete method
+    @transaction.atomic
+    def delete(self, request, event_id):
+        try:
+            event_instance = MeetEvent.objects.get(id=event_id)
+        except MeetEvent.DoesNotExist:
+            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+        
+        try:
+            Heat.objects.filter(event=event_instance).delete()
+        except Exception as e:
+            transaction.set_rollback(True)
+            return Response({'error': f'Failed to delete heats: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        
+        return Response({'success': 'Associated heats deleted'}, status=status.HTTP_200_OK)
 
     def get_queryset(self, group_id):
         try:

--- a/backend/api/views/GenerateHeatView.py
+++ b/backend/api/views/GenerateHeatView.py
@@ -6,7 +6,6 @@ from api.models import MeetEvent, Heat, Group, Athlete
 from api.serializers.GenerateHeatSerializer import GenerateHeatSerializer
 from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema
-from rest_framework.permissions import IsAuthenticated
 from django.db import transaction
 from django.db.models import F, Value, Func, IntegerField
 from django.utils import timezone


### PR DESCRIPTION
This PR address issue #57 

**Implementation**

1. **backend/api/serializers/GenerateHeatSerializer.py**

Added two serializers:

- `AthleteSeedSerializer`: Contains two fields, athlete of type `PrimaryKeyRelatedField`  and seed_time of type `HeatDurationField`.
- `GenerateHeatSerializer`: Introduces a unique field athletes of type `AthleteSeedSerializer`, expecting multiple records.
This serializer has two functions:
      ` create`: Accepts a list of athletes, sorts them by seed time, and generates corresponding heats.
      `calculate_lane_num`: An auxiliary function to calculate the lane number of an athlete.

2. **backend/api/views/GenerateHeatView.py**
This view utilizes `GenerateHeatSerializer` and comprises three functions:

- `get_queryset`: Accepts a group_id and filters all athletes corresponding to that group.
- `post`: Receives an event_id along with a list of athletes and their seed times, then creates heats corresponding to that event.
- `delete`: Given an `event_id`, removes all heats related to that event.

3. **backend/api/urls.py**

Introduced the event_heat/<int:event_id>/ endpoint that utilizes GenerateHeatView.