### PR TITLE
BE - Use CustomUser in CustomTokenRefreshSerializer

### DIFF
--- a/backend/api/serializers/CustomTokenRefreshSerializer.py
+++ b/backend/api/serializers/CustomTokenRefreshSerializer.py
@@ -1,5 +1,5 @@
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
-from django.contrib.auth.models import User
+from api.models import CustomUser
 from rest_framework_simplejwt.state import token_backend
 from rest_framework_simplejwt.utils import datetime_from_epoch, aware_utcnow
 from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
@@ -19,7 +19,7 @@ class CustomTokenRefreshSerializer(TokenRefreshSerializer):
 
         # decode the new refresh token to obtain the token information
         new_refresh_token_payload = token_backend.decode(refresh_token)
-        user = User.objects.get(pk=new_refresh_token_payload['user_id'])
+        user = CustomUser.objects.get(pk=new_refresh_token_payload['user_id'])
         jti = new_refresh_token_payload["jti"]
         exp = new_refresh_token_payload["exp"]
         current_time = aware_utcnow()


### PR DESCRIPTION
This PR fixes #80 

### Implementation


**_1. backend/api/serializers/CustomTokenRefreshSerializer.py_**

The CustomTokenRefreshSerializer was originally implemented to use the default User model provided by django but a custom user model was implemented for our project by PR #35. 
The CustomTokenRefreshSerializer should now import the CustomUser model and use it.


### Swagger
The endpoint /api/login/refresh/ is now working and generating a new access token and refresh token when a request with is received:
<img width="1153" alt="Screenshot 2024-04-30 at 10 06 44 PM" src="https://github.com/MarisiaS/SMM/assets/102187795/ebc37763-25df-4d0f-98dd-302729277c29">
