### PR TITLE
FE - Fix Swim meet display bugs

### DIFF
--- a/backend/api/fixtures/swim_meet.json
+++ b/backend/api/fixtures/swim_meet.json
@@ -3,7 +3,7 @@
         "model": "api.swimmeet",
         "pk": 1,
         "fields": {
-            "name": "Spring Swim Meet",
+            "name": "Spring Swim Meet 1",
             "date": "2024-03-16",
             "time": "17:00:00",
             "site": 1
@@ -13,10 +13,271 @@
         "model": "api.swimmeet",
         "pk": 2,
         "fields": {
-            "name": "Flying Fish Swim Meet",
+            "name": "Flying Fish Swim Meet 1",
             "date": "2024-04-29",
             "time": "12:00:00",
             "site": 1
         }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 3,
+        "fields": {
+            "name": "Spring Swim Meet 2",
+            "date": "2024-04-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 4,
+        "fields": {
+            "name": "Flying Fish Swim Meet 2",
+            "date": "2024-05-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 5,
+        "fields": {
+            "name": "Spring Swim Meet 3",
+            "date": "2024-05-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 6,
+        "fields": {
+            "name": "Flying Fish Swim Meet 3",
+            "date": "2024-06-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 7,
+        "fields": {
+            "name": "Spring Swim Meet 4",
+            "date": "2024-06-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 8,
+        "fields": {
+            "name": "Flying Fish Swim Meet 4",
+            "date": "2024-07-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 9,
+        "fields": {
+            "name": "Spring Swim Meet 5",
+            "date": "2024-07-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 10,
+        "fields": {
+            "name": "Flying Fish Swim Meet 5",
+            "date": "2024-08-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 11,
+        "fields": {
+            "name": "Spring Swim Meet 6",
+            "date": "2024-08-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 12,
+        "fields": {
+            "name": "Flying Fish Swim Meet 6",
+            "date": "2024-09-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 13,
+        "fields": {
+            "name": "Spring Swim Meet 7",
+            "date": "2024-09-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 14,
+        "fields": {
+            "name": "Flying Fish Swim Meet 7",
+            "date": "2024-10-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 15,
+        "fields": {
+            "name": "Spring Swim Meet 8",
+            "date": "2024-10-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 16,
+        "fields": {
+            "name": "Flying Fish Swim Meet 8",
+            "date": "2024-11-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 17,
+        "fields": {
+            "name": "Spring Swim Meet 9",
+            "date": "2024-11-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 18,
+        "fields": {
+            "name": "Flying Fish Swim Meet 9",
+            "date": "2024-12-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 19,
+        "fields": {
+            "name": "Spring Swim Meet 10",
+            "date": "2024-12-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 20,
+        "fields": {
+            "name": "Flying Fish Swim Meet 10",
+            "date": "2025-01-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 21,
+        "fields": {
+            "name": "Spring Swim Meet 11",
+            "date": "2025-01-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 22,
+        "fields": {
+            "name": "Flying Fish Swim Meet 11",
+            "date": "2025-02-28",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 23,
+        "fields": {
+            "name": "Spring Swim Meet 12",
+            "date": "2025-02-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 24,
+        "fields": {
+            "name": "Flying Fish Swim Meet 12",
+            "date": "2025-03-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 25,
+        "fields": {
+            "name": "Spring Swim Meet 13",
+            "date": "2025-03-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 26,
+        "fields": {
+            "name": "Flying Fish Swim Meet 13",
+            "date": "2025-04-29",
+            "time": "12:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 27,
+        "fields": {
+            "name": "Spring Swim Meet 14",
+            "date": "2025-04-16",
+            "time": "17:00:00",
+            "site": 1
+        }
+    },
+    {
+        "model": "api.swimmeet",
+        "pk": 28,
+        "fields": {
+            "name": "Flying Fish Swim Meet 14",
+            "date": "2025-05-29",
+            "time": "12:00:00",
+            "site": 1
+        }
     }
+
 ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.15.18",
         "@mui/x-date-pickers": "^7.5.1",
         "axios": "^1.6.8",
+        "dayjs": "^1.11.13",
         "material-react-table": "^2.13.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2268,6 +2269,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.15.18",
     "@mui/x-date-pickers": "^7.5.1",
     "axios": "^1.6.8",
+    "dayjs": "^1.11.13",
     "material-react-table": "^2.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect } from "react";
+import dayjs from "dayjs";
 import { SmmApi } from "../SmmApi";
 import GenericTable from "../components/Common/GenericTable";
 import SearchBar from "../components/Common/SearchBar";
@@ -6,7 +7,7 @@ import PaginationBar from "../components/Common/PaginationBar";
 import {
   Edit as EditIcon,
   Delete as DeleteIcon,
-  ContentPasteSearch as DetailsIcon,
+  ContentPaste as DetailsIcon,
   EmojiEvents as RankingIcon,
   Add as AddIcon
 } from "@mui/icons-material";
@@ -74,8 +75,14 @@ const SwimMeetDisplay = () => {
       const json = await SmmApi.getSwimMeetList(searchPar, offset, limit);
       console.log(json);
       if (!ignore) {
-        setData(json.results);
-        setCount(json.count);
+        const formattedData = json.results.map(item => ({
+          ...item,
+          date: dayjs(item.date).format('MM/DD/YYYY'),
+          time: item.time.slice(0, 5),
+        }));
+
+        setData(formattedData);
+        setCount(json.count)
       }
     }
     fetching();

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -24,6 +24,7 @@ const GenericTable = ({ data, columns, actions }) => {
     enableTopToolbar: false,
     enableBottomToolbar: false,
     enableColumnActions: false,
+    enablePagination: false,
 
     renderRowActions: ({ row }) => (
       <Box>

--- a/frontend/src/components/Common/PaginationBar.jsx
+++ b/frontend/src/components/Common/PaginationBar.jsx
@@ -28,7 +28,7 @@ export default function PaginationBar({ count, setOffset, setLimit }) {
       onPageChange={handleChangePage}
       rowsPerPage={rowsPerPage}
       onRowsPerPageChange={handleChangeRowsPerPage}
-      rowsPerPageOptions={[5,10,20,30]}
+      rowsPerPageOptions={[5,10,15,20]}
       sx={{
         color: theme.palette.text.primary,
       }}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -11,11 +11,10 @@ import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
-import InboxIcon from "@mui/icons-material/MoveToInbox";
+import PoolIcon from '@mui/icons-material/Pool';
 import { Link, useLocation, Outlet } from "react-router-dom";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
-import MyButton from "./FormElements/MyButton";
 
 const drawerWidth = 240;
 
@@ -62,7 +61,7 @@ export default function NavBar(props) {
                 onClick={handleOptionClick}
               >
                 <ListItemIcon>
-                  <InboxIcon />
+                  <PoolIcon />
                 </ListItemIcon>
                 <ListItemText primary={option.label} />
               </ListItemButton>


### PR DESCRIPTION
This PR addresses issue #90 

## **Implementation**

1. **frontend/src/components/NavBar.jsx*
Update the icon from InboxIcon to  PoolIcon in the navigation bar.

<img width="252" alt="Screenshot 2024-08-20 at 3 41 16 PM" src="https://github.com/user-attachments/assets/169302f9-38c2-43fb-911b-07cdad9b3761">

2. **frontend/src/components/Common/PaginationBar.jsx**
Update the rows per page option to include 20 instead of 30.
<img width="188" alt="Screenshot 2024-08-20 at 3 42 59 PM" src="https://github.com/user-attachments/assets/27747ad9-1d2f-4bef-9b6b-a26036381fb8">

3. **frontend/src/components/Common/GenericTable.jsx**
The table was showing 10 rows even when a different value was selected in the pagination bar. 
This issue is due to the `material-react-table` [by default has the option  `enablePagination` set to true](https://www.material-react-table.com/docs/guides/pagination#relevant-table-options) with a page limit of 10.
The option `enablePagination` is now set explicitly to false so the table doesn't implement the default pagination but the custom pagination implemented using the PaginationBar.

4. **frontend/src/SwimMeet/SwimMeetDisplay.jsx**
The details icon is updated to ContentPaste.

The date and time strings returned from the backend in the response are formatted as MM/dd/YYYY and HH:mm:

```
const formattedData = json.results.map(item => ({
          ...item,
          date: dayjs(item.date).format('MM/DD/YYYY'),
          time: item.time.slice(0, 5),
        }));

        setData(formattedData);
```

5. **frontend/package.json, frontend/package-lock.json**
Install dayjs

6. **backend/api/fixtures/swim_meet.json**
Add new swim meet objects to the fixture file in order to better test the pagination functionality in the frontend.

