### PR TITLE
FE-Swim Meet Display-Show error when unable to upload data

### DIFF
--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -111,6 +111,7 @@ const SwimMeetDisplay = () => {
 
           setData(formattedData);
           setCount(json.count);
+          setErrorOnLoading(false);
         }
       } catch (error) {
         setErrorOnLoading(true);

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -9,11 +9,12 @@ import {
   Delete as DeleteIcon,
   ContentPaste as DetailsIcon,
   EmojiEvents as RankingIcon,
-  Add as AddIcon
+  Add as AddIcon,
 } from "@mui/icons-material";
 import MyButton from "../components/FormElements/MyButton";
 import { Stack, Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
+import AlertBox from "../components/Common/AlertBox.jsx";
 
 const columns = [
   {
@@ -39,12 +40,18 @@ const columns = [
 ];
 
 const SwimMeetDisplay = () => {
+  const [errorOnLoading, setErrorOnLoading] = useState(false);
   const [data, setData] = useState([]);
   const [searchPar, setSearchPar] = useState("");
   const navigate = useNavigate();
   const [offset, setOffset] = useState(0);
   const [count, setCount] = useState(0);
   const [limit, setLimit] = useState(10);
+
+  let typeAlertLoading = errorOnLoading ? "error" : "success";
+  let messageOnLoading = errorOnLoading
+    ? "Data upload failed. Please try again!"
+    : "";
 
   const handleDetailsClick = (id) => {
     console.log("Details ...", id);
@@ -63,26 +70,50 @@ const SwimMeetDisplay = () => {
   };
 
   const actions = [
-    { name: "Details", icon: <DetailsIcon />, onClick: handleDetailsClick, tip:"Go to events" },
-    { name: "Edit", icon: <EditIcon />, onClick: handleEditClick, tip:"Edit basic information" },
-    { name: "Delete", icon: <DeleteIcon />, onClick: handleDeleteClick, tip: "Delete" },
-    { name: "Ranking", icon: <RankingIcon />, onClick: handleRankingClick, tip: "Go to ranking" },
+    {
+      name: "Details",
+      icon: <DetailsIcon />,
+      onClick: handleDetailsClick,
+      tip: "Go to events",
+    },
+    {
+      name: "Edit",
+      icon: <EditIcon />,
+      onClick: handleEditClick,
+      tip: "Edit basic information",
+    },
+    {
+      name: "Delete",
+      icon: <DeleteIcon />,
+      onClick: handleDeleteClick,
+      tip: "Delete",
+    },
+    {
+      name: "Ranking",
+      icon: <RankingIcon />,
+      onClick: handleRankingClick,
+      tip: "Go to ranking",
+    },
   ];
 
   useEffect(() => {
     let ignore = false;
     async function fetching() {
-      const json = await SmmApi.getSwimMeetList(searchPar, offset, limit);
-      console.log(json);
-      if (!ignore) {
-        const formattedData = json.results.map(item => ({
-          ...item,
-          date: dayjs(item.date).format('MM/DD/YYYY'),
-          time: item.time.slice(0, 5),
-        }));
+      try {
+        const json = await SmmApi.getSwimMeetList(searchPar, offset, limit);
+        console.log(json);
+        if (!ignore) {
+          const formattedData = json.results.map((item) => ({
+            ...item,
+            date: dayjs(item.date).format("MM/DD/YYYY"),
+            time: item.time.slice(0, 5),
+          }));
 
-        setData(formattedData);
-        setCount(json.count)
+          setData(formattedData);
+          setCount(json.count);
+        }
+      } catch (error) {
+        setErrorOnLoading(true);
       }
     }
     fetching();
@@ -95,22 +126,46 @@ const SwimMeetDisplay = () => {
     navigate("/add-swim-meet");
   };
 
-  return (
-    <div>
-      <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <Box sx={{ marginLeft: 5 }}>
-          <MyButton label={"Swim Meet"} onClick={handleAddNew}>
-            <AddIcon/>
-          </MyButton>
-        </Box>
-        <Box className={"searchBox"} sx={{ marginRight: 5 }}>
-          <SearchBar setSearchPar={setSearchPar}></SearchBar>
-        </Box>
+  if (errorOnLoading) {
+    return (
+      <Stack
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "16px",
+          width: "300px",
+          margin: "auto",
+        }}
+      >
+        <AlertBox type={typeAlertLoading} message={messageOnLoading} />
       </Stack>
-      <GenericTable data={data} columns={columns} actions={actions} />
-      <PaginationBar count={count} setOffset={setOffset} setLimit={setLimit}></PaginationBar>
-    </div>
-  );
+    );
+  } else {
+    return (
+      <div>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Box sx={{ marginLeft: 5 }}>
+            <MyButton label={"Swim Meet"} onClick={handleAddNew}>
+              <AddIcon />
+            </MyButton>
+          </Box>
+          <Box className={"searchBox"} sx={{ marginRight: 5 }}>
+            <SearchBar setSearchPar={setSearchPar}></SearchBar>
+          </Box>
+        </Stack>
+        <GenericTable data={data} columns={columns} actions={actions} />
+        <PaginationBar
+          count={count}
+          setOffset={setOffset}
+          setLimit={setLimit}
+        ></PaginationBar>
+      </div>
+    );
+  }
 };
 
 export default SwimMeetDisplay;


### PR DESCRIPTION
This PR addresses issue #96  

When there is an issue connecting to the API to retrieve the swim meet data, the table is currently showing the message "There is no records to display":

<img width="1906" alt="Screenshot 2024-08-21 at 9 34 17 AM" src="https://github.com/user-attachments/assets/c0bdf6f8-371b-4dec-be09-a19a741f8b95">

It would be better to display a message stating an error.

## **Implementation**

1. **frontend/src/SwimMeet/SwimMeetDisplay.jsx*
Add a try catch block when trying sending the request to the API. Catch the error and set a boolean variable to True to indicate there was an issue loading the data.

Add  an If else block, In case this variable is True, return an alert box indicating an error loading data, else return the components as usual (table displaying the data).


In case of an error retrieving the data:
<img width="1209" alt="Screenshot 2024-08-24 at 8 39 46 AM" src="https://github.com/user-attachments/assets/07f3bc3f-b49d-4a93-b088-04830c267100">


Data loaded successfully:
<img width="1719" alt="Screenshot 2024-08-24 at 11 06 44 AM" src="https://github.com/user-attachments/assets/54951cc4-6107-4e4e-b1d4-6c9419c94307">

