### PR TITLE
FE- SwimMeetForm styling

### DIFF
--- a/frontend/src/Event/AddEventForm.jsx
+++ b/frontend/src/Event/AddEventForm.jsx
@@ -8,7 +8,6 @@ const AddEventForm = ({ handleSubmit, control, handleCancel, options }) => {
 
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
-      <Stack alignItems="center" justifyContent="space-between">
         <Stack>
           <Box className={"itemBox"}>
             <MySelect
@@ -38,7 +37,6 @@ const AddEventForm = ({ handleSubmit, control, handleCancel, options }) => {
             onClick={handleCancel}
           />
         </Stack>
-      </Stack>
     </form>
   );
 };

--- a/frontend/src/Event/AddEventForm.jsx
+++ b/frontend/src/Event/AddEventForm.jsx
@@ -1,5 +1,5 @@
 import "../App.css";
-import { Box, Stack, Container } from "@mui/material";
+import { Box, Stack} from "@mui/material";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
 

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -1,5 +1,5 @@
 import "../App.css";
-import { Box, Stack, Container } from "@mui/material";
+import { Box, Stack} from "@mui/material";
 import MyTextField from "../components/FormElements/MyTextField.jsx";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import MyDatePicker from "../components/FormElements/MyDatePicker.jsx";

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -45,7 +45,7 @@ const SwimMeetForm = ({ handleSubmit, control, handleCancel, options }) => {
           />
         </Box>
       </Stack>
-      <Stack Stack className={"itemBox"}>
+      <Stack className={"itemBox"}>
         <MyButton key={"create"} label={"Create"} type={"submit"} />
         <Box sx={{ marginTop: 2 }}></Box>
         <MyButton

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -9,56 +9,50 @@ import MySelect from "../components/FormElements/MySelect.jsx";
 const SwimMeetForm = ({ handleSubmit, control, handleCancel, options }) => {
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
-      <Stack alignItems="center" justifyContent="space-between">
-        <Stack>
-          <Box className={"itemBox"}>
-            <MyTextField
-              label={"Swim Meet Name"}
-              name={"name"}
-              control={control}
-              rules={{ required: "Name is required" }}
-            />
-          </Box>
-          <Box className={"itemBox"}>
-            <MyDatePicker
-              label={"Date"}
-              name={"date"}
-              control={control}
-              disablePast={true}
-              rules={{ required: "Date is required" }}
-            />
-          </Box>
-          <Box className={"itemBox"}>
-            <MyTimePicker
-              label={"Time"}
-              name={"time"}
-              control={control}
-              rules={{ required: "Time is required" }}
-            />
-          </Box>
-          <Box className={"itemBox"}>
-            <MySelect
-              label={"Site"}
-              name={"site"}
-              control={control}
-              options={options}
-              rules={{ required: "Site is required" }}
-            />
-          </Box>
-        </Stack>
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-        >
-          <Box className={"itemBox"} sx={{ marginLeft: 5 }}>
-            <MyButton key={"cancel"} label={"Cancel"} onClick={handleCancel} />
-          </Box>
-          <Box sx={{ marginLeft: 5, marginRight: 5 }}></Box>
-          <Box className={"itemBox"} sx={{ marginRight: 5 }}>
-            <MyButton key={"create"} label={"Create"} type={"submit"} />
-          </Box>
-        </Stack>
+      <Stack>
+        <Box className={"itemBox"}>
+          <MyTextField
+            label={"Swim Meet Name"}
+            name={"name"}
+            control={control}
+            rules={{ required: "Name is required" }}
+          />
+        </Box>
+        <Box className={"itemBox"}>
+          <MyDatePicker
+            label={"Date"}
+            name={"date"}
+            control={control}
+            disablePast={true}
+            rules={{ required: "Date is required" }}
+          />
+        </Box>
+        <Box className={"itemBox"}>
+          <MyTimePicker
+            label={"Time"}
+            name={"time"}
+            control={control}
+            rules={{ required: "Time is required" }}
+          />
+        </Box>
+        <Box className={"itemBox"}>
+          <MySelect
+            label={"Site"}
+            name={"site"}
+            control={control}
+            options={options}
+            rules={{ required: "Site is required" }}
+          />
+        </Box>
+      </Stack>
+      <Stack Stack className={"itemBox"}>
+        <MyButton key={"create"} label={"Create"} type={"submit"} />
+        <Box sx={{ marginTop: 2 }}></Box>
+        <MyButton
+          key={"cancel"}
+          label={"Go to Swim Meets"}
+          onClick={handleCancel}
+        />
       </Stack>
     </form>
   );


### PR DESCRIPTION
This PR addresses issue #112 

### Description

The `SwimMeetForm` component's button styling has been updated to match the layout used in the `AddEventForm` component. Additionally, unnecessary Stack components have been removed from the `AddEventForm` to ensure uniformity in element widths.

### Implementation

- **frontend/src/SwimMeet/SwimMeetForm.jsx**

  -   Buttons are now stacked vertically to match the style of the `AddEventForm`.
  -  The "Cancel" button label has been updated to "GO TO SWIM MEETS" for clarity.

- **frontend/src/Event/AddEventForm.jsx**

Removed unnecessary Stack components, resulting in all form elements (e.g., selects and buttons) having the same width.


### Updated Appearance

- SwimMeetForm

![image](https://github.com/user-attachments/assets/d590ca19-0db8-4942-ba97-06713d96797f)

- AddEventForm (Before & After) 
  - With Stack:

![image](https://github.com/user-attachments/assets/66c17b3e-d5da-4523-a240-60d33d022423)

  - Without Stack:

![image](https://github.com/user-attachments/assets/c6d04354-c1c3-45bf-8814-5afc06bed683)
