### PR TITLE
FE- Tab Panel Component

### DIFF
--- a/frontend/Tests/TestTabPanel.jsx
+++ b/frontend/Tests/TestTabPanel.jsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { MoveUp as BackIcon, Add as AddIcon } from "@mui/icons-material";
+import TabPanel from "../src/components/Common/TabPanel";
+import SwimMeetDisplay from "../src/SwimMeet/SwimMeetDisplay";
+import AddSwimMeet from "../src/SwimMeet/AddSwimMeet";
+
+const TestTabs = () => {
+  const handleByHeatsClick = () => {
+    console.log("Heats");
+  };
+
+  const handleByLanesClick = () => {
+    console.log("Lanes");
+  };
+
+  const tabs = [
+    {
+      label: "Heats",
+      onClick: handleByHeatsClick,
+      content: <SwimMeetDisplay />,
+    },
+    {
+      label: "Lanes",
+      onClick: handleByLanesClick,
+      content: <AddSwimMeet />,
+    },
+  ];
+
+  return (
+    <div className={"test"}>
+      <TabPanel tabs={tabs} />
+    </div>
+  );
+};
+
+export default TestTabs;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import SwimMeetDisplay from "./SwimMeet/SwimMeetDisplay";
 import AddSwimMeet from "./SwimMeet/AddSwimMeet";
 import MeetEventDisplay from "./Event/MeetEventDisplay";
 import AddEvent from "./Event/AddEvent";
+import TestTabPanel from "../Tests/TestTabPanel";
 
 function App() {
   const NotFound = () => {
@@ -36,6 +37,8 @@ function App() {
           <Route path="/add-event/:meetId" element={<AddEvent />} />
         </Route>
       </Route>
+      // Routes for testing component behavior during development
+      <Route path="/tests/test-tab-panel" element={<TestTabPanel />} />
     </Routes>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import SwimMeetDisplay from "./SwimMeet/SwimMeetDisplay";
 import AddSwimMeet from "./SwimMeet/AddSwimMeet";
 import MeetEventDisplay from "./Event/MeetEventDisplay";
 import AddEvent from "./Event/AddEvent";
-import TestTabPanel from "../Tests/TestTabPanel";
+import TestTabPanel from "./Tests/TestTabPanel";
 
 function App() {
   const NotFound = () => {

--- a/frontend/src/Tests/TestTabPanel.jsx
+++ b/frontend/src/Tests/TestTabPanel.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { MoveUp as BackIcon, Add as AddIcon } from "@mui/icons-material";
-import TabPanel from "../src/components/Common/TabPanel";
-import SwimMeetDisplay from "../src/SwimMeet/SwimMeetDisplay";
-import AddSwimMeet from "../src/SwimMeet/AddSwimMeet";
+import TabPanel from "../components/Common/TabPanel";
+import SwimMeetDisplay from "../SwimMeet/SwimMeetDisplay";
+import AddSwimMeet from "../SwimMeet/AddSwimMeet";
 
 const TestTabs = () => {
   const handleByHeatsClick = () => {

--- a/frontend/src/components/Common/TabPanel.jsx
+++ b/frontend/src/components/Common/TabPanel.jsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Box from "@mui/material/Box";
+
+export default function TabPanel({ tabs, defaultTab = 0 }) {
+  const [activeTab, setActiveTab] = React.useState(defaultTab);
+
+  const onTabChange = (event, newValue) => {
+    setActiveTab(newValue);
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTab}
+          onChange={onTabChange}
+          aria-label="tabs"
+          variant="fullWidth"
+        >
+          {tabs.map((tab, index) => (
+            <Tab key={index} label={tab.label} />
+          ))}
+        </Tabs>
+      </Box>
+      <Box sx={{ p: 2 }}>{tabs[activeTab]?.content}</Box>
+    </Box>
+  );
+}

--- a/frontend/src/theme.jsx
+++ b/frontend/src/theme.jsx
@@ -1,24 +1,24 @@
 // src/theme.js
-import { createTheme } from '@mui/material/styles';
+import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#1976d2', // Main blue shade
-      light: '#63a4ff',
-      dark: '#004ba0',
-      contrastText: '#fff',
+      main: "#1976d2", // Main blue shade
+      light: "#63a4ff",
+      dark: "#004ba0",
+      contrastText: "#fff",
     },
     secondary: {
-      main: '#90caf9', // Lighter blue shade
-      light: '#c3fdff',
-      dark: '#5d99c6',
-      contrastText: '#000',
+      main: "#90caf9", // Lighter blue shade
+      light: "#c3fdff",
+      dark: "#5d99c6",
+      contrastText: "#000",
     },
-    
+
     text: {
-      primary: '#000000', //Black for text
-      secondary: '#0d47a1', // Slightly lighter blue for secondary text
+      primary: "#000000", //Black for text
+      secondary: "#0d47a1", // Slightly lighter blue for secondary text
     },
   },
   typography: {


### PR DESCRIPTION
This PR addresses issue #107 

### Description

This PR introduces a reusable component that display tabs to switch between different views.

### Implementation
It implements a tab component using [Material UI Tabs and Tab components](https://mui.com/material-ui/react-tabs/).

1. New component:
- TabPanel

  - Location: components/Common folder
  - Props: 
    -  `tabs`: An array that contains the information to display for each tab: label, onClick and content.
    - `defaultTab`: A numeric value to specify the default active tab index (optional, default to 0)
  - Behavior:
    - Displays one tab for each object in the `tabs` array with its label.
    - In a Box, it displays the `content` for the active tab.


- Testing

  - frontend/Tests/TestTabPanel.jsx
 A parent component for testing the `TabPanel` component. It defines a tab list with two objects which specify a label, onClick and content.
  - frontend/src/App.jsx
 The following test route was added to facilitate testing of the `TabPanel` component:
`      <Route path="/tests/test-tab-panel" element={<TestTabPanel />} />
`

### UI Preview

Tab Panel View with 2 tabs (Heats and Lanes) with the Heats tab active. For testing purposes, the `SwimMeetDisplay` component is displayed as a content.

<img width="1720" alt="Screenshot 2024-09-17 at 12 54 12 PM" src="https://github.com/user-attachments/assets/838744a0-6893-4e15-bcfe-43bf48a21f30">

Tab Panel View with 2 tabs (Heats and Lanes) with the Lanes tab active. For testing purposes, the `AddSwimMeet` component is displayed as a content.
<img width="1714" alt="Screenshot 2024-09-17 at 12 54 26 PM" src="https://github.com/user-attachments/assets/96a64601-6ee5-4f6e-8a04-5c13144b4777">
