### PR TITLE
FE - Select Table component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,8 @@ import AddEvent from "./Event/AddEvent";
 import TestTabPanel from "./Tests/TestTabPanel";
 import TestItemPaginationBar from "./Tests/TestItemPaginationBar";
 import TestExpandableTable from "./Tests/TestExpandableTable";
+import TestSelectTable from "./Tests/TestSelectTable";
+
 
 function App() {
   const NotFound = () => {
@@ -43,6 +45,7 @@ function App() {
       <Route path="/tests/test-tab-panel" element={<TestTabPanel />} />
       <Route path="/tests/test-item-pagination-bar" element={<TestItemPaginationBar />} />
       <Route path="/tests/test-expandable-table" element={<TestExpandableTable />} />
+      <Route path="/tests/test-select-table" element={<TestSelectTable />} />
     </Routes>
   );
 }

--- a/frontend/src/Tests/TestSelectTable.jsx
+++ b/frontend/src/Tests/TestSelectTable.jsx
@@ -1,0 +1,207 @@
+import "../App.css";
+import { useState } from "react";
+import SelectTable from "../components/Common/SelectTable";
+import MyIconButton from "../components/FormElements/MyIconButton";
+import { Box, Stack } from "@mui/material";
+import {
+  NavigateBefore as LeftIcon,
+  NavigateNext as RightIcon,
+  KeyboardDoubleArrowRight as RightAllIcon,
+  KeyboardDoubleArrowLeft as LeftAllIcon,
+} from "@mui/icons-material";
+
+const testData = [
+  {
+    id: 2,
+    athlete_full_name: "Ana Gomez",
+    seed_time: "45.10",
+  },
+  {
+    id: 10,
+    athlete_full_name: "Anna Anderson",
+    seed_time: "38.54",
+  },
+  {
+    id: 16,
+    athlete_full_name: "Ava Wilson",
+    seed_time: "37.81",
+  },
+  {
+    id: 4,
+    athlete_full_name: "Elena Lopez",
+    seed_time: "39.21",
+  },
+  {
+    id: 12,
+    athlete_full_name: "Ellie Yuan",
+    seed_time: "41.84",
+  },
+  {
+    id: 8,
+    athlete_full_name: "Kyla Smith",
+    seed_time: "41.54",
+  },
+  {
+    id: 6,
+    athlete_full_name: "Laura Sanchez",
+    seed_time: "31.36",
+  },
+  {
+    id: 15,
+    athlete_full_name: "Olivia Davis",
+    seed_time: "38.54",
+  },
+  {
+    id: 11,
+    athlete_full_name: "Sofia Avila",
+    seed_time: "NT",
+  },
+];
+
+const mainTableColumns = [
+  {
+    accessorKey: "athlete_full_name",
+    header: "",
+    size: 150,
+  },
+  {
+    accessorKey: "seed_time",
+    header: "",
+    size: 150,
+  },
+];
+
+const TestSelectTable = () => {
+  const [availableData, setAvailableData] = useState(testData);
+  const [selectedData, setSelectedData] = useState([]);
+  const [selectedRightData, setSelectedRightData] = useState({});
+  const [selectedLeftData, setSelectedLeftData] = useState({});
+
+  const onRightSelected = () => {
+    //Move selected items from left table to right table
+    const dataToMove = availableData.filter(
+      (item) => item.id in selectedRightData
+    );
+    setSelectedData((prevSelectedData) => {
+      const updatedData = [...prevSelectedData, ...dataToMove];
+      return updatedData.sort((a, b) =>
+        a.athlete_full_name.localeCompare(b.athlete_full_name)
+      );
+    });
+    // Update available data by filtering out the moved items
+    setAvailableData((prevAvailableData) =>
+      prevAvailableData.filter(
+        (item) => !(item.id in selectedRightData) // Filter out moved items
+      )
+    );
+    // Clear selectedRightData
+    setSelectedRightData({});
+  };
+
+  const onRightAll = () => {
+    // Move all items to the right table
+    setAvailableData([]);
+    setSelectedData(testData);
+    setSelectedLeftData([]);
+    setSelectedRightData([]);
+  };
+
+  const onLeftAll = () => {
+    // Move all items back to the left table
+    setAvailableData(testData);
+    setSelectedData([]);
+    setSelectedLeftData([]);
+    setSelectedRightData([]);
+  };
+
+  const onLeftSelected = () => {
+    // Move selected items back to the left table
+    const dataToMove = selectedData.filter(
+      (item) => item.id in selectedLeftData
+    );
+    setAvailableData((prevAvailableData) => {
+      const updatedData = [...prevAvailableData, ...dataToMove];
+      return updatedData.sort((a, b) =>
+        a.athlete_full_name.localeCompare(b.athlete_full_name)
+      );
+    });
+    // Update available data by filtering out the moved items
+    setSelectedData((prevSelectedData) =>
+      prevSelectedData.filter(
+        (item) => !(item.id in selectedLeftData) // Filter out moved items
+      )
+    );
+    // Clear selectedRightData
+    setSelectedLeftData({});
+  };
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        width: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        className={"test"}
+        sx={{ gap: "15px", width: "80%", height: "auto", margin: "2px" }}
+      >
+        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
+          <SelectTable
+            data={availableData}
+            columns={mainTableColumns}
+            selection={selectedRightData}
+            rowSelection={selectedRightData}
+            setRowSelection={setSelectedRightData}
+          />
+        </Box>
+
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <MyIconButton
+            onClick={onRightSelected}
+            disabled={Object.keys(selectedRightData).length === 0}
+          >
+            <RightIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onRightAll}
+            disabled={availableData.length === 0}
+          >
+            <RightAllIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onLeftAll}
+            disabled={availableData.length === testData.length}
+          >
+            <LeftAllIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onLeftSelected}
+            disabled={Object.keys(selectedLeftData).length === 0}
+          >
+            <LeftIcon />
+          </MyIconButton>
+        </Box>
+
+        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
+          <SelectTable
+            data={selectedData}
+            columns={mainTableColumns}
+            rowSelection={selectedLeftData}
+            setRowSelection={setSelectedLeftData}
+          />
+        </Box>
+      </Box>
+    </div>
+  );
+};
+
+export default TestSelectTable;

--- a/frontend/src/components/Common/SelectTable.jsx
+++ b/frontend/src/components/Common/SelectTable.jsx
@@ -45,6 +45,9 @@ const SelectTable = ({ data, columns, rowSelection, setRowSelection }) => {
         overflowX: "hidden", // Disable horizontal scrolling
       },
     },
+    localization: {
+        noRecordsToDisplay: "", //No message when the table is empty
+      },
   });
 
   return <MaterialReactTable table={table} />;

--- a/frontend/src/components/Common/SelectTable.jsx
+++ b/frontend/src/components/Common/SelectTable.jsx
@@ -1,0 +1,53 @@
+import {
+  MaterialReactTable,
+  useMaterialReactTable,
+} from "material-react-table";
+
+const SelectTable = ({ data, columns, rowSelection, setRowSelection }) => {
+  const table = useMaterialReactTable({
+    data: data,
+    columns: columns,
+    enableRowSelection: true, // Enable row selection
+    enableSelectAll: false, // Disable the "Select All" checkbox
+    muiTableBodyRowProps: ({ row }) => ({
+      // Select row on click
+      onClick: (event) => row.getToggleSelectedHandler()(event), // Toggle selection on row click
+      style: {
+        cursor: "pointer",
+        userSelect: "none", // Prevent text selection
+      },
+    }),
+    displayColumnDefOptions: {
+      "mrt-row-select": { header: "" }, // Hide the header for the selection column
+    },
+    muiTableHeadProps: {
+      sx: {
+        visibility: "collapse", // Hide table headers but keep the layout intact
+      },
+    },
+    getRowId: (originalRow) => originalRow.id, // Use 'id' as the unique identifier for rows
+    onRowSelectionChange: setRowSelection, // Sync row selection state with parent component
+    state: { rowSelection }, // Pass the current row selection state to the table
+    enableRowVirtualization: true, // Allow vertical scrolling for rows
+    enableSorting: false,
+    initialState: { density: "compact", showGlobalFilter: true }, // Show search input (GlobalFilter)
+    enableTopToolbar: true,
+    enableToolbarInternalActions: false,
+    positionToolbarAlertBanner: "bottom", // Display an alert banner at the bottom with selection info
+    enableBottomToolbar: true,
+    enableColumnActions: false,
+    enablePagination: false,
+    muiTableBodyProps: {
+      sx: {
+        maxHeight: "400px", // Set a maximum height for the table body
+        minHeight: "400px", // Set a minimum height for the table body
+        overflowY: "auto", // Enable vertical scrolling
+        overflowX: "hidden", // Disable horizontal scrolling
+      },
+    },
+  });
+
+  return <MaterialReactTable table={table} />;
+};
+
+export default SelectTable;


### PR DESCRIPTION
This PR addresses issue #118.

### Description

This PR introduces a reusable `SelectTable` component that displays a table with selectable rows.

### Implementation

The component is built using [MaterialReactTable](https://www.material-react-table.com/docs/examples/advanced) and includes the following functionality: 

1. New component

- Component Name: SelectTable
- Location: components/Common folder
- Props:
  - `data`: Array of table data.
  - `columns`: Array of column configurations.
  - `rowSelection`: Object tracking selected rows.
  - `setRowSelection`: Callback function to update row selection state.
    
- Behavior:
  - The table has a fixed height of 400px and scrolls vertically when data exceeds this limit.
  - Rows can be selected or deselected by clicking on them.
  - Includes a search input (global filter).
  - The bottom banner displays the number of selected rows, with an option to clear selections.
  - The `rowSelection` prop tracks selected rows, and selections are updated via `setRowSelection`.
 

2. Testing 

- Test Component: `frontend/src/Tests/TestSelectTable.jsx`
A test component (`TestSelectTable`) was created to render two instances of the `SelectTable` component, along with buttons to move data between the tables for testing.

- Test Route: Added a test route in frontend/src/App.jsx
     `<Route path="/tests/test-select-table" element={<TestSelectTable />} />`

### UI Preview

- Initial state of table
![image](https://github.com/user-attachments/assets/036e4127-9f2f-405f-9994-a32efc424bfc)

- Bottom banner
![image](https://github.com/user-attachments/assets/fa499def-e30b-48c7-87e1-eaeaebb2eda3)

- Scroll when data does not fit.
![image](https://github.com/user-attachments/assets/53ec32c8-4f0c-45ca-96f5-450d90663002)

- Data selected on the left table

![image](https://github.com/user-attachments/assets/27012ff8-6d46-46ad-9439-efa91bba1b9b)

- Data selected on the right table

![image](https://github.com/user-attachments/assets/1caecd5d-b966-407b-bdc9-e687e6fa7860)

- Data selected on both tables

![image](https://github.com/user-attachments/assets/ca60f12b-415d-4746-a12c-b1c67845bd4d)


- Search performed on the left table

![image](https://github.com/user-attachments/assets/ecd5583f-5496-44b0-8505-c952a61cdc92)

