### PR TITLE
FE-Conditional action render on tables

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,9 +42,18 @@ function App() {
       </Route>
       // Routes for testing component behavior during development
       <Route path="/tests/test-tab-panel" element={<TestTabPanel />} />
-      <Route path="/tests/test-item-pagination-bar" element={<TestItemPaginationBar />} />
-      <Route path="/tests/test-expandable-table" element={<TestExpandableTable />} />
-      <Route path="/tests/test-conditional-render" element={<TestConditionalRender />} />
+      <Route
+        path="/tests/test-item-pagination-bar"
+        element={<TestItemPaginationBar />}
+      />
+      <Route
+        path="/tests/test-expandable-table"
+        element={<TestExpandableTable />}
+      />
+      <Route
+        path="/tests/test-conditional-render"
+        element={<TestConditionalRender />}
+      />
     </Routes>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import AddEvent from "./Event/AddEvent";
 import TestTabPanel from "./Tests/TestTabPanel";
 import TestItemPaginationBar from "./Tests/TestItemPaginationBar";
 import TestExpandableTable from "./Tests/TestExpandableTable";
+import TestConditionalRender from "./Tests/TestConditionalRender";
 
 function App() {
   const NotFound = () => {
@@ -43,6 +44,7 @@ function App() {
       <Route path="/tests/test-tab-panel" element={<TestTabPanel />} />
       <Route path="/tests/test-item-pagination-bar" element={<TestItemPaginationBar />} />
       <Route path="/tests/test-expandable-table" element={<TestExpandableTable />} />
+      <Route path="/tests/test-conditional-render" element={<TestConditionalRender />} />
     </Routes>
   );
 }

--- a/frontend/src/Tests/TestConditionalRender.jsx
+++ b/frontend/src/Tests/TestConditionalRender.jsx
@@ -106,7 +106,7 @@ const TestConditionalRender = () => {
       icon: <EditIcon />,
       onClick: handleEditClick,
       tip: "Edit athletes",
-      visible: (row) => row.original.name == "Heat 1",
+      visible: (row) => row.original.name === "Heat 1",
     },
     {
       name: "Delete",

--- a/frontend/src/Tests/TestConditionalRender.jsx
+++ b/frontend/src/Tests/TestConditionalRender.jsx
@@ -1,165 +1,64 @@
 import ExpandableTable from "../components/Common/ExpandableTable";
 import GenericTable from "../components/Common/GenericTable";
-import {
-    Edit as EditIcon,
-} from "@mui/icons-material";
+import { Typography } from "@mui/material";
+import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
 
 const testData = [
-    {
-      id: 1,
-      name: "Heat 1",
-      heats: [
-        {
-          id: 12,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 13,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 22,
-          lane: 3,
-          athlete_full_name: "Carlos",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 4,
-          athlete_full_name: "Gerardo",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 24,
-          lane: 5,
-          athlete_full_name: "Pedro",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 2,
-      name: "Heat 2",
-      heats: [
-        {
-          id: 14,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 3,
-      name: "Heat 3",
-      heats: [
-        {
-          id: 22,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 4,
-      name: "Heat 4",
-      heats: [
-        {
-          id: 22,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 5,
-      name: "Heat 5",
-      heats: [
-        {
-          id: 22,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 6,
-      name: "Heat 6",
-      heats: [
-        {
-          id: 22,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-    {
-      id: 7,
-      name: "Heat 7",
-      heats: [
-        {
-          id: 22,
-          lane: 1,
-          athlete_full_name: "Hola",
-          seed_time: 2,
-          heat_time: "",
-        },
-        {
-          id: 23,
-          lane: 2,
-          athlete_full_name: "Adios",
-          seed_time: 2,
-          heat_time: "",
-        },
-      ],
-    },
-  ];
+  {
+    id: 1,
+    name: "Heat 1",
+    heats: [
+      {
+        id: 12,
+        lane: 1,
+        athlete_full_name: "Hola",
+        seed_time: 2,
+        heat_time: "",
+      },
+      {
+        id: 13,
+        lane: 2,
+        athlete_full_name: "Adios",
+        seed_time: 2,
+        heat_time: "",
+      },
+      {
+        id: 22,
+        lane: 3,
+        athlete_full_name: "Carlos",
+        seed_time: 2,
+        heat_time: "",
+      },
+      {
+        id: 23,
+        lane: 4,
+        athlete_full_name: "Gerardo",
+        seed_time: 2,
+        heat_time: "",
+      },
+      {
+        id: 24,
+        lane: 5,
+        athlete_full_name: "Pedro",
+        seed_time: 2,
+        heat_time: "",
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: "Heat 2",
+    heats: [
+      {
+        id: 14,
+        lane: 1,
+        athlete_full_name: "Hola",
+        seed_time: 2,
+        heat_time: "",
+      },
+    ],
+  },
+];
 
 const mainTableColumns = [
   {
@@ -193,29 +92,54 @@ const subTableColumns = [
 ];
 
 const TestConditionalRender = () => {
+  const handleEditClick = () => {
+    console.log("Edit ...");
+  };
 
-    const handleEditClick = () => {
-        console.log("Edit ...");
-      };
+  const handleDeleteClick = () => {
+    console.log("Delete ...");
+  };
 
-    const actions = [
-        {
-          name: "Edit",
-          icon: <EditIcon />,
-          onClick: handleEditClick,
-          tip: "Edit athletes",
-          visible: (row) => row.original.name == "Heat 1",
-        },
-      ];
+  const actions = [
+    {
+      name: "Edit",
+      icon: <EditIcon />,
+      onClick: handleEditClick,
+      tip: "Edit athletes",
+      visible: (row) => row.original.name == "Heat 1",
+    },
+    {
+      name: "Delete",
+      icon: <DeleteIcon />,
+      onClick: handleDeleteClick,
+      tip: "Delete",
+    },
+  ];
   return (
     <div>
+      <Typography
+        key={1}
+        variant={"h4"}
+        component="div"
+        sx={{ color: "text.secondary" }}
+      >
+        Expandable table
+      </Typography>
       <ExpandableTable
         data={testData}
         columns={mainTableColumns}
         actions={actions}
         subTableColumns={subTableColumns}
-        subData={'heats'}
+        subData={"heats"}
       />
+      <Typography
+        key={2}
+        variant={"h4"}
+        component="div"
+        sx={{ color: "text.secondary" }}
+      >
+        Generic table
+      </Typography>
       <GenericTable
         data={testData}
         columns={mainTableColumns}

--- a/frontend/src/Tests/TestConditionalRender.jsx
+++ b/frontend/src/Tests/TestConditionalRender.jsx
@@ -1,0 +1,228 @@
+import ExpandableTable from "../components/Common/ExpandableTable";
+import GenericTable from "../components/Common/GenericTable";
+import {
+    Edit as EditIcon,
+} from "@mui/icons-material";
+
+const testData = [
+    {
+      id: 1,
+      name: "Heat 1",
+      heats: [
+        {
+          id: 12,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 13,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 22,
+          lane: 3,
+          athlete_full_name: "Carlos",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 4,
+          athlete_full_name: "Gerardo",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 24,
+          lane: 5,
+          athlete_full_name: "Pedro",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: "Heat 2",
+      heats: [
+        {
+          id: 14,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 3,
+      name: "Heat 3",
+      heats: [
+        {
+          id: 22,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: "Heat 4",
+      heats: [
+        {
+          id: 22,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 5,
+      name: "Heat 5",
+      heats: [
+        {
+          id: 22,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 6,
+      name: "Heat 6",
+      heats: [
+        {
+          id: 22,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+    {
+      id: 7,
+      name: "Heat 7",
+      heats: [
+        {
+          id: 22,
+          lane: 1,
+          athlete_full_name: "Hola",
+          seed_time: 2,
+          heat_time: "",
+        },
+        {
+          id: 23,
+          lane: 2,
+          athlete_full_name: "Adios",
+          seed_time: 2,
+          heat_time: "",
+        },
+      ],
+    },
+  ];
+
+const mainTableColumns = [
+  {
+    accessorKey: "name",
+    header: "",
+    size: 150,
+  },
+];
+
+const subTableColumns = [
+  {
+    accessorKey: "lane",
+    header: "Lane",
+    size: 150,
+  },
+  {
+    accessorKey: "athlete_full_name",
+    header: "Athlete",
+    size: 150,
+  },
+  {
+    accessorKey: "seed_time",
+    header: "Seed Time",
+    size: 150,
+  },
+  {
+    accessorKey: "heat_time",
+    header: "Heat Time",
+    size: 150,
+  },
+];
+
+const TestConditionalRender = () => {
+
+    const handleEditClick = () => {
+        console.log("Edit ...");
+      };
+
+    const actions = [
+        {
+          name: "Edit",
+          icon: <EditIcon />,
+          onClick: handleEditClick,
+          tip: "Edit athletes",
+          visible: (row) => row.original.name == "Heat 1",
+        },
+      ];
+  return (
+    <div>
+      <ExpandableTable
+        data={testData}
+        columns={mainTableColumns}
+        actions={actions}
+        subTableColumns={subTableColumns}
+        subData={'heats'}
+      />
+      <GenericTable
+        data={testData}
+        columns={mainTableColumns}
+        actions={actions}
+      />
+    </div>
+  );
+};
+
+export default TestConditionalRender;

--- a/frontend/src/components/Common/ExpandableTable.jsx
+++ b/frontend/src/components/Common/ExpandableTable.jsx
@@ -44,30 +44,38 @@ const ExpandableTable = ({
     renderRowActions: ({ row }) => (
       <Box>
         {actions &&
-          actions.map((action, index) => (
-            <Tooltip
-              key={index}
-              title={action.tip}
-              placement="top"
-              arrow
-              slotProps={{
-                popper: {
-                  modifiers: [
-                    {
-                      name: "offset",
-                      options: {
-                        offset: [0, -20],
-                      },
+          actions.map((action, index) => {
+            let shouldRender = true;
+            if (action.visible) {
+              shouldRender = action.visible(row);
+            }
+            return (
+              shouldRender && (
+                <Tooltip
+                  key={index}
+                  title={action.tip}
+                  placement="top"
+                  arrow
+                  slotProps={{
+                    popper: {
+                      modifiers: [
+                        {
+                          name: "offset",
+                          options: {
+                            offset: [0, -20],
+                          },
+                        },
+                      ],
                     },
-                  ],
-                },
-              }}
-            >
-              <IconButton onClick={() => action.onClick(row.id)}>
-                {action.icon}
-              </IconButton>
-            </Tooltip>
-          ))}
+                  }}
+                >
+                  <IconButton onClick={() => action.onClick(row.id)}>
+                    {action.icon}
+                  </IconButton>
+                </Tooltip>
+              )
+            );
+          })}
       </Box>
     ),
 

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -30,44 +30,44 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage }) => {
 
     renderRowActions: ({ row }) => (
       <Box>
-      {actions &&
-        actions.map((action, index) => {
-          let shouldRender = true;
-          if (action.visible) {
-            shouldRender = action.visible(row);
-          }
-          return (
-            shouldRender && (
-              <Tooltip
-                key={index}
-                title={action.tip}
-                placement="top"
-                arrow
-                slotProps={{
-                  popper: {
-                    modifiers: [
-                      {
-                        name: "offset",
-                        options: {
-                          offset: [0, -20],
+        {actions &&
+          actions.map((action, index) => {
+            let shouldRender = true;
+            if (action.visible) {
+              shouldRender = action.visible(row);
+            }
+            return (
+              shouldRender && (
+                <Tooltip
+                  key={index}
+                  title={action.tip}
+                  placement="top"
+                  arrow
+                  slotProps={{
+                    popper: {
+                      modifiers: [
+                        {
+                          name: "offset",
+                          options: {
+                            offset: [0, -20],
+                          },
                         },
-                      },
-                    ],
-                  },
-                }}
-              >
-                <IconButton onClick={() => action.onClick(row.id)}>
-                  {action.icon}
-                </IconButton>
-              </Tooltip>
-            )
-          );
-        })}
-    </Box>
+                      ],
+                    },
+                  }}
+                >
+                  <IconButton onClick={() => action.onClick(row.id)}>
+                    {action.icon}
+                  </IconButton>
+                </Tooltip>
+              )
+            );
+          })}
+      </Box>
     ),
   });
 
-  return <MaterialReactTable table={table}  />;
+  return <MaterialReactTable table={table} />;
 };
 
 export default GenericTable;

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -30,32 +30,40 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage }) => {
 
     renderRowActions: ({ row }) => (
       <Box>
-        {actions &&
-          actions.map((action, index) => (
-            <Tooltip
-              key={index}
-              title={action.tip}
-              placement="top"
-              arrow
-              slotProps={{
-                popper: {
-                  modifiers: [
-                    {
-                      name: "offset",
-                      options: {
-                        offset: [0, -20],
+      {actions &&
+        actions.map((action, index) => {
+          let shouldRender = true;
+          if (action.visible) {
+            shouldRender = action.visible(row);
+          }
+          return (
+            shouldRender && (
+              <Tooltip
+                key={index}
+                title={action.tip}
+                placement="top"
+                arrow
+                slotProps={{
+                  popper: {
+                    modifiers: [
+                      {
+                        name: "offset",
+                        options: {
+                          offset: [0, -20],
+                        },
                       },
-                    },
-                  ],
-                },
-              }}
-            >
-              <IconButton onClick={() => action.onClick(row.id)}>
-                {action.icon}
-              </IconButton>
-            </Tooltip>
-          ))}
-      </Box>
+                    ],
+                  },
+                }}
+              >
+                <IconButton onClick={() => action.onClick(row.id)}>
+                  {action.icon}
+                </IconButton>
+              </Tooltip>
+            )
+          );
+        })}
+    </Box>
     ),
   });
 


### PR DESCRIPTION
This PR address issue #121.

### Description 

The action buttons in `GenericTable` and `ExpandableTable` are now rendered based on an optional visible field in the action object.

### Implementation

- `GenericTable` and `ExpandableTable`:
  -  In `renderRowActions`, if an action has a `visible` property, it will evaluate the row data to determine whether the action should render.
  - Actions without a `visible` key will be rendered by default.

### Testing

- Test component: `frontend/src/Tests/TestConditionalRender.jsx`
  - Displays two items with "edit" and "delete" actions.
  -  "Delete" is always rendered.
  - "Edit" is conditionally rendered when name === "Heat 1".
- Test Route: Added a test route in frontend/src/App.jsx
<Route path="/tests/test-conditional-render" element={<TestConditionalRender />} />

### UI Preview
In the preview below, the "Delete" action is rendered for all rows, while "Edit" is rendered only for the row where name === "Heat 1".
![image](https://github.com/user-attachments/assets/dab189a5-2fac-4f10-a392-425267890fed)



