### PR TITLE
FE- Add API methods related to heats and lanes

### DIFF
--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -124,7 +124,6 @@ export class SmmApi {
     let res = await axios.get(url, {
       headers: getConfig(),
     });
-    console.log(res.data);
     return res.data;
   }
 

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -152,4 +152,40 @@ export class SmmApi {
       headers: getConfig(),
     });
   }
+
+  static async getEventHeats(eventId) {
+    return await axios.get(`${BASE_URL}/event_heat/${eventId}/`, {
+      headers: getConfig(),
+    });
+  }
+
+  static async createHeats(eventId, data) {
+    return await axios.post(`${BASE_URL}/event_heat/${eventId}/`, data, {
+      headers: getConfig(),
+    });
+  }
+
+  static async deleteHeats(eventId) {
+    return await axios.delete(`${BASE_URL}/event_heat/${eventId}/`, {
+      headers: getConfig(),
+    });
+  }
+
+  static async getHeatDetails(eventId, heatNum) {
+    return await axios.get(`${BASE_URL}/event_heat/${eventId}/${heatNum}/`, {
+      headers: getConfig(),
+    });
+  }
+
+  static async getEventLanes(eventId) {
+    return await axios.get(`${BASE_URL}/event_lane/${eventId}/`, {
+      headers: getConfig(),
+    });
+  }
+
+  static async getLaneDetails(eventId, laneNum) {
+    return await axios.get(`${BASE_URL}/event_lane/${eventId}/${laneNum}/`, {
+      headers: getConfig(),
+    });
+  }
 }


### PR DESCRIPTION
This PR addresses issue #117 

### Description

This PR adds new methods in the SmmApi class to handle API requests related to event heats and lanes. 

### Implementation
In the `frontend/src/SmmApi.jsx` file, the following methods were added:

- `getEventHeats(eventId)`: Sends a GET request to fetch all the heats associated with an specific event (`eventId`).
- `createHeats(eventId, data)`: Sends a POST request to generate all heats for an event (`eventId`).
- `deleteHeats(eventId)`: Sends a DELETE request to delete all heats from the event  (`eventId`).
- `getHeatDetails(eventId, heatNum)`: Sends a GET request to fetch the details of an specific heat (`heatNum`) in an event (`eventId`).
- `getEventLanes(eventId)`: Sends a GET request to fetch all lanes associated with an event (`eventId`).
 
- `getLaneDetails(eventId, laneNum)`: Sends a GET request to fetch the details of a specific lane (`laneNum`) in an event (`eventId`).