### PR TITLE
BE-AthleteSeedTimeSerializer change

### DIFF
--- a/backend/api/serializers/AthleteSeedTimeSerializer.py
+++ b/backend/api/serializers/AthleteSeedTimeSerializer.py
@@ -7,12 +7,12 @@ from rest_framework.exceptions import ValidationError
 
 
 class AthleteSeedTimeSerializer(serializers.Serializer):
-    athlete = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
+    id = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
     athlete_full_name = serializers.CharField()
     seed_time = HeatDurationField()
 
 class UpdateAthleteSeedTimeSerializer(serializers.Serializer):
-    athlete = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
+    id = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
     date = serializers.DateTimeField()
     time = serializers.DurationField()
 
@@ -26,7 +26,7 @@ class UpdateAthleteSeedTimeSerializer(serializers.Serializer):
     def create(self,validated_data):
         try:
             record_instance = TimeRecord.objects.create(
-                athlete = validated_data.get('athlete'),
+                athlete = validated_data.get('id'),
                 event_type = self.context['event_type'],
                 time = validated_data.get('time'),
                 date = validated_data.get('date')

--- a/backend/api/views/AtheleteSeedTimeView.py
+++ b/backend/api/views/AtheleteSeedTimeView.py
@@ -80,10 +80,10 @@ class AthleteSeedTimeView(APIView):
             time_records = TimeRecord.objects.filter(athlete=athlete, event_type=event_type_instance).order_by('time')
             if time_records.exists():
                 seed_time = time_records.first()
-                seed_times.append({'athlete': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': seed_time.time})
+                seed_times.append({'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': seed_time.time})
             else:
                 # The serializer interpretes 200 days as NT (No time)
-                seed_times.append({'athlete': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': timedelta(days=200)})
+                seed_times.append({'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': timedelta(days=200)})
 
         paginator = LimitOffsetPagination()
         paginated_seed_times = paginator.paginate_queryset(seed_times, request)

--- a/backend/api/views/AtheleteSeedTimeView.py
+++ b/backend/api/views/AtheleteSeedTimeView.py
@@ -95,7 +95,8 @@ class AthleteSeedTimeView(APIView):
         # Return the paginated response
         return paginator.get_paginated_response(serializer.data)
 
-    @extend_schema(request=UpdateAthleteSeedTimeSerializer)
+    @extend_schema(request=UpdateAthleteSeedTimeSerializer,
+                   summary="Record or update the seed time for a specific athlete in the given event")
     def post(self, request, event_id):
         try:
             event_instance = MeetEvent.objects.get(id=event_id)


### PR DESCRIPTION
This PR addresses issue #119.

### Description
The `AthleteSeedTimeSerializer` is currently using the athlete field to identify the athlete by their ID. We need to change this field to id to ensure consistency and simplify data handling by referencing athletes using their unique identifier (id).

### Implementation

1. **backend/api/serializers/AthleteSeedTimeSerializer.py**

- `athlete` field was renamed `id` on `AthleteSeedTimeSerializer`.
- `athlete` field was renamed `id` on `UpdateAthleteSeedTimeSerializer` and `create` function was updated to reflect the change.

2. **backend/api/views/AtheleteSeedTimeView.py**

- `athlete` field was renamed `id` .
- Added a summary to the `post` method.