### PR TITLE
FE - ItemPaginationBar update

### DIFF
--- a/frontend/src/Tests/TestItemPaginationBar.jsx
+++ b/frontend/src/Tests/TestItemPaginationBar.jsx
@@ -113,7 +113,7 @@ const TestItemPaginationBar = () => {
       <ItemPaginationBar
         label={data[itemIndex].name}
         extraActions={extraActionsNoNav}
-        enableButtonNavigation={false}
+        enableNavigationButtons={false}
       ></ItemPaginationBar>
     </div>
   );

--- a/frontend/src/Tests/TestItemPaginationBar.jsx
+++ b/frontend/src/Tests/TestItemPaginationBar.jsx
@@ -113,7 +113,7 @@ const TestItemPaginationBar = () => {
       <ItemPaginationBar
         label={data[itemIndex].name}
         extraActions={extraActionsNoNav}
-        disableNav={true}
+        enableButtonNavigation={false}
       ></ItemPaginationBar>
     </div>
   );

--- a/frontend/src/Tests/TestItemPaginationBar.jsx
+++ b/frontend/src/Tests/TestItemPaginationBar.jsx
@@ -95,6 +95,15 @@ const TestItemPaginationBar = () => {
         disableNext={isLastItem}
         extraActions={extraActions}
       ></ItemPaginationBar>
+      <ItemPaginationBar
+        label={data[itemIndex].name}
+        onPrevious={handlePrevious}
+        onNext={handleNext}
+        disablePrevious={isFirstItem}
+        disableNext={isLastItem}
+        extraActions={extraActions}
+        disableNav={true}
+      ></ItemPaginationBar>
     </div>
   );
 };

--- a/frontend/src/Tests/TestItemPaginationBar.jsx
+++ b/frontend/src/Tests/TestItemPaginationBar.jsx
@@ -82,6 +82,21 @@ const TestItemPaginationBar = () => {
       label: "Add event",
       icon: <AddIcon />,
       onClick: handleAddClick,
+      disabled: itemIndex === 0,
+    },
+  ];
+
+  const extraActionsNoNav = [
+    {
+      label: "Back to events",
+      icon: <BackIcon />,
+      onClick: handleBackClick,
+    },
+    {
+      label: "Add event",
+      icon: <AddIcon />,
+      onClick: handleAddClick,
+      disabled: itemIndex === 1,
     },
   ];
 
@@ -97,11 +112,7 @@ const TestItemPaginationBar = () => {
       ></ItemPaginationBar>
       <ItemPaginationBar
         label={data[itemIndex].name}
-        onPrevious={handlePrevious}
-        onNext={handleNext}
-        disablePrevious={isFirstItem}
-        disableNext={isLastItem}
-        extraActions={extraActions}
+        extraActions={extraActionsNoNav}
         disableNav={true}
       ></ItemPaginationBar>
     </div>

--- a/frontend/src/components/Common/ItemPaginationBar.jsx
+++ b/frontend/src/components/Common/ItemPaginationBar.jsx
@@ -36,7 +36,7 @@ const ItemPaginationBar = ({
         {extraActions &&
           extraActions.map((action, index) => (
             <Box key={index}>
-              <MyButton label={action.label} onClick={action.onClick}>
+              <MyButton label={action.label} onClick={action.onClick} disabled = {action.disabled}>
                 {action.icon}
               </MyButton>
             </Box>

--- a/frontend/src/components/Common/ItemPaginationBar.jsx
+++ b/frontend/src/components/Common/ItemPaginationBar.jsx
@@ -8,7 +8,6 @@ import {
   NavigateNext as NextIcon,
 } from "@mui/icons-material";
 
-
 const ItemPaginationBar = ({
   label,
   onPrevious,
@@ -16,6 +15,7 @@ const ItemPaginationBar = ({
   disablePrevious,
   disableNext,
   extraActions,
+  disableNav = false,
 }) => {
   return (
     <div>
@@ -23,12 +23,12 @@ const ItemPaginationBar = ({
         <Box className={"labelBox"} sx={{ marginLeft: 5 }}>
           <h2>{label}</h2>
         </Box>
-        <Box sx={{ marginLeft: 5 }}>
+        <Box sx={{ marginLeft: 5, visibility: disableNav ? 'hidden' : 'visible' }}>
           <MyIconButton onClick={onPrevious} disabled={disablePrevious}>
             <PreviousIcon />
           </MyIconButton>
         </Box>
-        <Box sx={{ marginRight: 5 }}>
+        <Box sx={{ marginRight: 5, visibility: disableNav ? 'hidden' : 'visible' }}>
           <MyIconButton onClick={onNext} disabled={disableNext}>
             <NextIcon />
           </MyIconButton>

--- a/frontend/src/components/Common/ItemPaginationBar.jsx
+++ b/frontend/src/components/Common/ItemPaginationBar.jsx
@@ -14,7 +14,7 @@ const ItemPaginationBar = ({
   disablePrevious,
   disableNext,
   extraActions,
-  enableButtonNavigation = true,
+  enableNavigationButtons = true,
 }) => {
   return (
     <div>
@@ -22,12 +22,12 @@ const ItemPaginationBar = ({
         <Box className={"labelBox"} sx={{ marginLeft: 5 }}>
           <h2>{label}</h2>
         </Box>
-        <Box sx={{ marginLeft: 5, visibility: enableButtonNavigation ? 'visible' : 'hidden'  }}>
+        <Box sx={{ marginLeft: 5, visibility: enableNavigationButtons ? 'visible' : 'hidden'  }}>
           <MyIconButton onClick={onPrevious} disabled={disablePrevious}>
             <PreviousIcon />
           </MyIconButton>
         </Box>
-        <Box sx={{ marginRight: 5, visibility: enableButtonNavigation ? 'visible' : 'hidden' }}>
+        <Box sx={{ marginRight: 5, visibility: enableNavigationButtons ? 'visible' : 'hidden' }}>
           <MyIconButton onClick={onNext} disabled={disableNext}>
             <NextIcon />
           </MyIconButton>

--- a/frontend/src/components/Common/ItemPaginationBar.jsx
+++ b/frontend/src/components/Common/ItemPaginationBar.jsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import MyIconButton from "../FormElements/MyIconButton";
 import MyButton from "../FormElements/MyButton";
 import { Stack, Box } from "@mui/material";
-import { styled } from "@mui/material/styles";
 import {
   NavigateBefore as PreviousIcon,
   NavigateNext as NextIcon,
@@ -15,7 +14,7 @@ const ItemPaginationBar = ({
   disablePrevious,
   disableNext,
   extraActions,
-  disableNav = false,
+  enableButtonNavigation = true,
 }) => {
   return (
     <div>
@@ -23,12 +22,12 @@ const ItemPaginationBar = ({
         <Box className={"labelBox"} sx={{ marginLeft: 5 }}>
           <h2>{label}</h2>
         </Box>
-        <Box sx={{ marginLeft: 5, visibility: disableNav ? 'hidden' : 'visible' }}>
+        <Box sx={{ marginLeft: 5, visibility: enableButtonNavigation ? 'visible' : 'hidden'  }}>
           <MyIconButton onClick={onPrevious} disabled={disablePrevious}>
             <PreviousIcon />
           </MyIconButton>
         </Box>
-        <Box sx={{ marginRight: 5, visibility: disableNav ? 'hidden' : 'visible' }}>
+        <Box sx={{ marginRight: 5, visibility: enableButtonNavigation ? 'visible' : 'hidden' }}>
           <MyIconButton onClick={onNext} disabled={disableNext}>
             <NextIcon />
           </MyIconButton>


### PR DESCRIPTION
This PR addresses issue #127 .

### Implementation

1. frontend/src/components/Common/ItemPaginationBar.jsx

- Added the `disableNav` prop, defaulting to false.
- When `disableNav` is true, the boxes containing the "Previous" and "Next" buttons are hidden but still occupy space.
- Added the disabled property to each button rendered in the `extraActions`.

2. frontend/src/Tests/TestItemPaginationBar.jsx

- Added an extra `ItemPaginationBar` test case with `disableNav` set to true.
- Updated the buttons in the test to include the disabled property.

**UI preview** 

- The second `ItemPaginationBar` does not display the "Previous" and "Next" buttons. The "Add Event" button is disabled in this instance.

![image](https://github.com/user-attachments/assets/04bbe369-e9ad-4491-a5ec-fe919d8b6506)

- In the first `ItemPaginationBar`, the "Add Event" button is disabled.

![image](https://github.com/user-attachments/assets/65b578be-9002-4e93-87fb-e6ad9a72e2cc)

-  All buttons are enabled in this view.

![image](https://github.com/user-attachments/assets/6de15be7-fd97-4ad4-96f6-05166e732727)
