### PR TITLE
FE - Select table update

### DIFF
--- a/frontend/src/Tests/TestSelectTable.jsx
+++ b/frontend/src/Tests/TestSelectTable.jsx
@@ -58,16 +58,29 @@ const testData = [
   },
 ];
 
-const mainTableColumns = [
+const availableColumns = [
   {
     accessorKey: "athlete_full_name",
-    header: "",
+    header: "Available athletes",
     size: 150,
   },
   {
     accessorKey: "seed_time",
-    header: "",
+    header: "Seed time",
+    size: 100,
+  },
+];
+
+const selectedColumns = [
+  {
+    accessorKey: "athlete_full_name",
+    header: "Selected athletes",
     size: 150,
+  },
+  {
+    accessorKey: "seed_time",
+    header: "Seed time",
+    size: 100,
   },
 ];
 
@@ -154,7 +167,7 @@ const TestSelectTable = () => {
         <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
           <SelectTable
             data={availableData}
-            columns={mainTableColumns}
+            columns={availableColumns}
             selection={selectedRightData}
             rowSelection={selectedRightData}
             setRowSelection={setSelectedRightData}
@@ -195,7 +208,7 @@ const TestSelectTable = () => {
         <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
           <SelectTable
             data={selectedData}
-            columns={mainTableColumns}
+            columns={selectedColumns}
             rowSelection={selectedLeftData}
             setRowSelection={setSelectedLeftData}
             notRecordsMessage={"No athletes selected."}

--- a/frontend/src/Tests/TestSelectTable.jsx
+++ b/frontend/src/Tests/TestSelectTable.jsx
@@ -158,6 +158,7 @@ const TestSelectTable = () => {
             selection={selectedRightData}
             rowSelection={selectedRightData}
             setRowSelection={setSelectedRightData}
+            notRecordsMessage={"No athletes available."}
           />
         </Box>
 
@@ -197,6 +198,7 @@ const TestSelectTable = () => {
             columns={mainTableColumns}
             rowSelection={selectedLeftData}
             setRowSelection={setSelectedLeftData}
+            notRecordsMessage={"No athletes selected."}
           />
         </Box>
       </Box>

--- a/frontend/src/components/Common/SelectTable.jsx
+++ b/frontend/src/components/Common/SelectTable.jsx
@@ -3,7 +3,7 @@ import {
   useMaterialReactTable,
 } from "material-react-table";
 
-const SelectTable = ({ data, columns, rowSelection, setRowSelection }) => {
+const SelectTable = ({ data, columns, rowSelection, setRowSelection, notRecordsMessage }) => {
   const table = useMaterialReactTable({
     data: data,
     columns: columns,
@@ -46,7 +46,7 @@ const SelectTable = ({ data, columns, rowSelection, setRowSelection }) => {
       },
     },
     localization: {
-        noRecordsToDisplay: "", //No message when the table is empty
+        noRecordsToDisplay: notRecordsMessage, //Message when the table is empty
       },
   });
 

--- a/frontend/src/components/Common/SelectTable.jsx
+++ b/frontend/src/components/Common/SelectTable.jsx
@@ -2,8 +2,16 @@ import {
   MaterialReactTable,
   useMaterialReactTable,
 } from "material-react-table";
+import { useTheme } from "@mui/material";
 
-const SelectTable = ({ data, columns, rowSelection, setRowSelection, notRecordsMessage }) => {
+const SelectTable = ({
+  data,
+  columns,
+  rowSelection,
+  setRowSelection,
+  notRecordsMessage,
+}) => {
+  const theme = useTheme();
   const table = useMaterialReactTable({
     data: data,
     columns: columns,
@@ -20,9 +28,10 @@ const SelectTable = ({ data, columns, rowSelection, setRowSelection, notRecordsM
     displayColumnDefOptions: {
       "mrt-row-select": { header: "" }, // Hide the header for the selection column
     },
-    muiTableHeadProps: {
+    muiTableHeadCellProps: {
       sx: {
-        visibility: "collapse", // Hide table headers but keep the layout intact
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
       },
     },
     getRowId: (originalRow) => originalRow.id, // Use 'id' as the unique identifier for rows
@@ -46,8 +55,8 @@ const SelectTable = ({ data, columns, rowSelection, setRowSelection, notRecordsM
       },
     },
     localization: {
-        noRecordsToDisplay: notRecordsMessage, //Message when the table is empty
-      },
+      noRecordsToDisplay: notRecordsMessage, //Message when the table is empty
+    },
   });
 
   return <MaterialReactTable table={table} />;


### PR DESCRIPTION
This PR addresses issue #128.

### Implementation

1. frontend/src/components/Common/SelectTable.jsx

- Added a new `notRecordsMessage` prop to specify the message to display when the table is empty.
- Made the header visible and applied the same styling as the `GenericTable`.

2. frontend/src/Tests/TestSelectTable.jsx

- Added the `notRecordsMessage` prop to both `SelectTable` instances.
- Each `SelectTable` now has its own columns object.

### UI preview

![image](https://github.com/user-attachments/assets/63891c46-33c5-461d-93a9-375f9fb5ee94)
