### PR TITLE
FE-Add Total Number of Heats for an Event and Conditionally render heat actions

### DIFF
--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -14,11 +14,17 @@ import {
 import MyButton from "../components/FormElements/MyButton.jsx";
 import { Stack, Box } from "@mui/material";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { Build as BuildIcon } from "@mui/icons-material";
 
 const columns = [
   {
     accessorKey: "name",
     header: "Event",
+    size: 150,
+  },
+  {
+    accessorKey: "total_num_heats",
+    header: " Number of Heats",
     size: 150,
   },
 ];
@@ -47,9 +53,13 @@ const MeetEventDisplay = () => {
     ? "Data upload failed. Please try again!"
     : "";
 
+  const handleGenerateClick = (id) => {
+    console.log("Go to Generate Heats");
+  };
+
   const handleDetailsClick = (id) => {
     setSelectedEventIndex(Number(id));
-    setShowEventDetails(true); 
+    setShowEventDetails(true);
   };
 
   const handleDeleteClick = (id) => {
@@ -62,10 +72,18 @@ const MeetEventDisplay = () => {
 
   const actions = [
     {
-      name: "Heats",
+      name: "Generate Heats",
+      icon: <BuildIcon />,
+      onClick: handleGenerateClick,
+      tip: "Generate heats",
+      visible: (row) => row.original.total_num_heats === 0,
+    },
+    {
+      name: "Heats Details",
       icon: <HeatIcon />,
       onClick: handleDetailsClick,
       tip: "Go to heats",
+      visible: (row) => row.original.total_num_heats > 0,
     },
     {
       name: "Delete",

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -10,11 +10,11 @@ import {
   Delete as DeleteIcon,
   EmojiEvents as RankingIcon,
   Add as AddIcon,
+  Build as BuildIcon,
 } from "@mui/icons-material";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import { Stack, Box } from "@mui/material";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Build as BuildIcon } from "@mui/icons-material";
 
 const columns = [
   {


### PR DESCRIPTION
This PR address issue #105 .

### Description 

The Meet Event details are displayed in a table, including the event name and a set of icons allowing the user to perform actions for the selected event row. The table should now include a column with the total number of heats. 
In case the total number of heats is 0, i.e. there are no heats for the event, the action generate heats (with its icon) should be displayed in the action options. Otherwise, when there are already heats for the event, the action go to heats should be displayed.

### Implementation

- `frontend/src/Event/MeetEventDisplay.jsx`:
  -  In `columns`, add a new column specification with accessorKey "`total_num_heats`" and header "Number of Heats".
  -  In `actions`, add a new action "Generate Heats" with icon BuildIcon and visible property conditionally set if total_num_heats is equal to zero.
 Update the action  with icon HeatIcon to "Heats Details" and visible property conditionally set if `total_num_heats` is greater than zero.

 -  Add the function `handleGenerateClick` which will be callen when onClick Generate Heats action. It will allow the user to add heats to that specific event (To Do). For now its just printing a console message.


### UI Preview
In the preview below, the "Number of Heats" column is displaying the total number of heat for each event. The first action icon is conditionally rendered based on the this value. If there are no heats (0), the generate heats action is displayed. If there are already heats (> 0), the go to heats action is displayed.

<img width="1703" alt="Screenshot 2024-10-14 at 3 55 36 PM" src="https://github.com/user-attachments/assets/7a97901d-ef56-427d-96de-5f78f29dd654">
