### PR TITLE
FE -  Add API methods related to seed times

### DIFF
--- a/backend/api/views/AtheleteSeedTimeView.py
+++ b/backend/api/views/AtheleteSeedTimeView.py
@@ -112,4 +112,4 @@ class AthleteSeedTimeView(APIView):
         serializer = UpdateAthleteSeedTimeSerializer(data=request.data, context={'event_type':event_type_instance})
         if serializer.is_valid(raise_exception=True):
             serializer.save()
-        return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response({'success': 'Time registered.'}, status=status.HTTP_200_OK)

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -187,4 +187,16 @@ export class SmmApi {
       headers: getConfig(),
     });
   }
+
+  static async getSeedTimes(eventId) {
+    return await axios.get(`${BASE_URL}/seed_times/${eventId}/`, {
+      headers: getConfig(),
+    });
+  }
+
+  static async registerSeedTime(eventId, data) {
+    return await axios.post(`${BASE_URL}/seed_times/${eventId}/`, data, {
+      headers: getConfig(),
+    });
+  }
 }


### PR DESCRIPTION
This PR addresses issue #129.

### Description
This pull request introduces new methods in the `SmmApi` class to facilitate API requests related to seed times for an given event.

### Implementation

In the `frontend/src/SmmApi.jsx` file, the following methods were added:

- `getSeedTimes(eventId)`: Sends a GET request to retrieve all athletes along with their respective seed times for a specified event (eventId).

- `registerSeedTime(eventId, data)`: Sends a POST request to record a seed time for a specific athlete in a specific event type (identified by eventId).

### Additional Change

In the `backend/api/views/AtheleteSeedTimeView.py`, the POST method was modified to return a success message upon successfully recording the seed time, rather than returning the serializer data.