### PR TITLE
FE - Athlete selection

### DIFF
--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -7,7 +7,7 @@ import { ContentPaste as BackIcon } from "@mui/icons-material";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { Build as BuildIcon } from "@mui/icons-material";
 import { Stack } from "@mui/material";
-import { formatSeedTime } from "../utils/helperFunctions.js"; 
+import { formatSeedTime } from "../utils/helperFunctions.js";
 
 const EventDetails = ({
   eventName,
@@ -15,6 +15,7 @@ const EventDetails = ({
   onBack,
   onPrevious,
   onNext,
+  onGenerate,
   disablePrevious,
   disableNext,
 }) => {
@@ -22,7 +23,7 @@ const EventDetails = ({
   const [heatData, setHeatData] = useState([]);
   const [laneData, setLaneData] = useState([]);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
-  const [selectedTab, setSelectedTab] = useState(0); 
+  const [selectedTab, setSelectedTab] = useState(0);
 
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading
@@ -149,13 +150,8 @@ const EventDetails = ({
 
   //Need for Generate heats AlertBox
 
-  const handleAddHeats = () => {
-    //Change it to add heats for the new event
-    console.log("Go to Generate Heats");
-  };
-
   let actionButtonsNoHeats = [
-    { label: "heats", onClick: handleAddHeats, icon: <BuildIcon /> },
+    { label: "heats", onClick: onGenerate, icon: <BuildIcon /> },
   ];
 
   return (
@@ -186,7 +182,7 @@ const EventDetails = ({
         <TabPanel
           tabs={tabs}
           selectedTab={selectedTab}
-          setSelectedTab={setSelectedTab} 
+          setSelectedTab={setSelectedTab}
         />
       ) : (
         <>

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -7,21 +7,7 @@ import { ContentPaste as BackIcon } from "@mui/icons-material";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { Build as BuildIcon } from "@mui/icons-material";
 import { Stack } from "@mui/material";
-
-const formatSeedTime = (seedTime) => {
-  if (!seedTime) return null;
-  if (seedTime === "NT") return "NT";
-  const timeParts = seedTime.split(":");
-  const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
-  if (timeParts[0] !== "00") {
-    return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
-  }
-  if (timeParts[1] !== "00") {
-    const minutes = parseInt(timeParts[1], 10);
-    return `${minutes}:${secondsAndMillis}`;
-  }
-  return `${secondsAndMillis}`;
-};
+import { formatSeedTime } from "../utils/helperFunctions.js"; 
 
 const EventDetails = ({
   eventName,

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -193,7 +193,6 @@ const MeetEventDisplay = () => {
     return (
       <div>
         <Title data={meetData} fields={["name", "date", "site_name"]} />
-
         {showEventDetails && eventData[selectedEventIndex] ? (
           <EventDetails
             eventName={eventData[selectedEventIndex].name}

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -5,6 +5,7 @@ import PaginationBar from "../components/Common/PaginationBar.jsx";
 import Title from "../components/Common/Title.jsx";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import EventDetails from "./EventDetails.jsx";
+import SelectAthlete from "../GenerateHeats/SelectAthlete.jsx";
 import {
   FormatAlignCenter as HeatIcon,
   Delete as DeleteIcon,
@@ -197,14 +198,11 @@ const MeetEventDisplay = () => {
             disableNext={isLastEvent}
           />
         ) : showGenerateHeats && eventData[selectedEventIndex] ? (
-          <EventDetails
+          //Need to change to select athletes
+          <SelectAthlete
             eventName={eventData[selectedEventIndex].name}
             eventId={eventData[selectedEventIndex].id}
             onBack={handleBackToEvents}
-            onPrevious={handlePreviousEvent}
-            onNext={handleNextEvent}
-            disablePrevious={isFirstEvent}
-            disableNext={isLastEvent}
           />
         ) : (
           <>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -39,6 +39,7 @@ const MeetEventDisplay = () => {
 
   //EventDetail states
   const [showEventDetails, setShowEventDetails] = useState(false);
+  const [showGenerateHeats, setShowGenerateHeats] = useState(false);
   const [selectedEventIndex, setSelectedEventIndex] = useState(null);
   const [navegationDirection, setNavegationDirection] = useState(null);
 
@@ -54,7 +55,8 @@ const MeetEventDisplay = () => {
     : "";
 
   const handleGenerateClick = (id) => {
-    console.log("Go to Generate Heats");
+    setSelectedEventIndex(Number(id));
+    setShowGenerateHeats(true);
   };
 
   const handleDetailsClick = (id) => {
@@ -131,6 +133,7 @@ const MeetEventDisplay = () => {
 
   const handleBackToEvents = () => {
     setShowEventDetails(false);
+    setShowGenerateHeats(false);
     setSelectedEventIndex(null);
   };
 
@@ -182,7 +185,18 @@ const MeetEventDisplay = () => {
     return (
       <div>
         <Title data={meetData} fields={["name", "date", "site_name"]} />
+
         {showEventDetails && eventData[selectedEventIndex] ? (
+          <EventDetails
+            eventName={eventData[selectedEventIndex].name}
+            eventId={eventData[selectedEventIndex].id}
+            onBack={handleBackToEvents}
+            onPrevious={handlePreviousEvent}
+            onNext={handleNextEvent}
+            disablePrevious={isFirstEvent}
+            disableNext={isLastEvent}
+          />
+        ) : showGenerateHeats && eventData[selectedEventIndex] ? (
           <EventDetails
             eventName={eventData[selectedEventIndex].name}
             eventId={eventData[selectedEventIndex].id}
@@ -206,7 +220,7 @@ const MeetEventDisplay = () => {
               </Box>
               <Box className={"searchBox"} sx={{ marginRight: 5 }}></Box>
             </Stack>
-            <br></br>
+            <br />
             <GenericTable
               data={eventData}
               columns={columns}
@@ -220,7 +234,7 @@ const MeetEventDisplay = () => {
               setLimit={setLimit}
               page={page}
               setPage={setPage}
-            ></PaginationBar>
+            />
           </>
         )}
       </div>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -58,11 +58,13 @@ const MeetEventDisplay = () => {
   const handleGenerateClick = (id) => {
     setSelectedEventIndex(Number(id));
     setShowGenerateHeats(true);
+    setShowEventDetails(false);
   };
 
   const handleDetailsClick = (id) => {
     setSelectedEventIndex(Number(id));
     setShowEventDetails(true);
+    setShowGenerateHeats(false);
   };
 
   const handleDeleteClick = (id) => {
@@ -138,6 +140,11 @@ const MeetEventDisplay = () => {
     setSelectedEventIndex(null);
   };
 
+  const handleGenerateButton = () => {
+    setShowEventDetails(false);
+    setShowGenerateHeats(true);
+  };
+
   const handlePreviousEvent = () => {
     if (selectedEventIndex > 0) {
       // Previous event on the same page
@@ -194,6 +201,7 @@ const MeetEventDisplay = () => {
             onBack={handleBackToEvents}
             onPrevious={handlePreviousEvent}
             onNext={handleNextEvent}
+            onGenerate={handleGenerateButton}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
           />

--- a/frontend/src/GenerateHeats/SelectAthlete.jsx
+++ b/frontend/src/GenerateHeats/SelectAthlete.jsx
@@ -1,0 +1,222 @@
+import "../App.css";
+import { useState } from "react";
+import SelectTable from "../components/Common/SelectTable";
+import MyIconButton from "../components/FormElements/MyIconButton";
+import { Box, Stack } from "@mui/material";
+import {
+  NavigateBefore as LeftIcon,
+  NavigateNext as RightIcon,
+  KeyboardDoubleArrowRight as RightAllIcon,
+  KeyboardDoubleArrowLeft as LeftAllIcon,
+} from "@mui/icons-material";
+
+const testData = [
+  {
+    id: 2,
+    athlete_full_name: "Ana Gomez",
+    seed_time: "45.10",
+  },
+  {
+    id: 10,
+    athlete_full_name: "Anna Anderson",
+    seed_time: "38.54",
+  },
+  {
+    id: 16,
+    athlete_full_name: "Ava Wilson",
+    seed_time: "37.81",
+  },
+  {
+    id: 4,
+    athlete_full_name: "Elena Lopez",
+    seed_time: "39.21",
+  },
+  {
+    id: 12,
+    athlete_full_name: "Ellie Yuan",
+    seed_time: "41.84",
+  },
+  {
+    id: 8,
+    athlete_full_name: "Kyla Smith",
+    seed_time: "41.54",
+  },
+  {
+    id: 6,
+    athlete_full_name: "Laura Sanchez",
+    seed_time: "31.36",
+  },
+  {
+    id: 15,
+    athlete_full_name: "Olivia Davis",
+    seed_time: "38.54",
+  },
+  {
+    id: 11,
+    athlete_full_name: "Sofia Avila",
+    seed_time: "NT",
+  },
+];
+
+const availableColumns = [
+  {
+    accessorKey: "athlete_full_name",
+    header: "Available athletes",
+    size: 150,
+  },
+  {
+    accessorKey: "seed_time",
+    header: "Seed time",
+    size: 100,
+  },
+];
+
+const selectedColumns = [
+  {
+    accessorKey: "athlete_full_name",
+    header: "Selected athletes",
+    size: 150,
+  },
+  {
+    accessorKey: "seed_time",
+    header: "Seed time",
+    size: 100,
+  },
+];
+
+const SelectAthlete = () => {
+  const [availableData, setAvailableData] = useState(testData);
+  const [selectedData, setSelectedData] = useState([]);
+  const [selectedRightData, setSelectedRightData] = useState({});
+  const [selectedLeftData, setSelectedLeftData] = useState({});
+
+  const onRightSelected = () => {
+    //Move selected items from left table to right table
+    const dataToMove = availableData.filter(
+      (item) => item.id in selectedRightData
+    );
+    setSelectedData((prevSelectedData) => {
+      const updatedData = [...prevSelectedData, ...dataToMove];
+      return updatedData.sort((a, b) =>
+        a.athlete_full_name.localeCompare(b.athlete_full_name)
+      );
+    });
+    // Update available data by filtering out the moved items
+    setAvailableData((prevAvailableData) =>
+      prevAvailableData.filter(
+        (item) => !(item.id in selectedRightData) // Filter out moved items
+      )
+    );
+    // Clear selectedRightData
+    setSelectedRightData({});
+  };
+
+  const onRightAll = () => {
+    // Move all items to the right table
+    setAvailableData([]);
+    setSelectedData(testData);
+    setSelectedLeftData([]);
+    setSelectedRightData([]);
+  };
+
+  const onLeftAll = () => {
+    // Move all items back to the left table
+    setAvailableData(testData);
+    setSelectedData([]);
+    setSelectedLeftData([]);
+    setSelectedRightData([]);
+  };
+
+  const onLeftSelected = () => {
+    // Move selected items back to the left table
+    const dataToMove = selectedData.filter(
+      (item) => item.id in selectedLeftData
+    );
+    setAvailableData((prevAvailableData) => {
+      const updatedData = [...prevAvailableData, ...dataToMove];
+      return updatedData.sort((a, b) =>
+        a.athlete_full_name.localeCompare(b.athlete_full_name)
+      );
+    });
+    // Update available data by filtering out the moved items
+    setSelectedData((prevSelectedData) =>
+      prevSelectedData.filter(
+        (item) => !(item.id in selectedLeftData) // Filter out moved items
+      )
+    );
+    // Clear selectedRightData
+    setSelectedLeftData({});
+  };
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        width: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        className={"test"}
+        sx={{ gap: "15px", width: "80%", height: "auto", margin: "2px" }}
+      >
+        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
+          <SelectTable
+            data={availableData}
+            columns={availableColumns}
+            selection={selectedRightData}
+            rowSelection={selectedRightData}
+            setRowSelection={setSelectedRightData}
+            notRecordsMessage={"No athletes available."}
+          />
+        </Box>
+
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <MyIconButton
+            onClick={onRightSelected}
+            disabled={Object.keys(selectedRightData).length === 0}
+          >
+            <RightIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onRightAll}
+            disabled={availableData.length === 0}
+          >
+            <RightAllIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onLeftAll}
+            disabled={availableData.length === testData.length}
+          >
+            <LeftAllIcon />
+          </MyIconButton>
+
+          <MyIconButton
+            onClick={onLeftSelected}
+            disabled={Object.keys(selectedLeftData).length === 0}
+          >
+            <LeftIcon />
+          </MyIconButton>
+        </Box>
+
+        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
+          <SelectTable
+            data={selectedData}
+            columns={selectedColumns}
+            rowSelection={selectedLeftData}
+            setRowSelection={setSelectedLeftData}
+            notRecordsMessage={"No athletes selected."}
+          />
+        </Box>
+      </Box>
+    </div>
+  );
+};
+
+export default SelectAthlete;

--- a/frontend/src/GenerateHeats/SelectAthlete.jsx
+++ b/frontend/src/GenerateHeats/SelectAthlete.jsx
@@ -4,6 +4,7 @@ import { SmmApi } from "../SmmApi.jsx";
 import SelectTable from "../components/Common/SelectTable";
 import MyIconButton from "../components/FormElements/MyIconButton";
 import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
 import { Box, Stack } from "@mui/material";
 import { formatSeedTime } from "../utils/helperFunctions.js";
 import {
@@ -39,6 +40,7 @@ const selectedColumns = [
     accessorKey: "seed_time",
     header: "Seed time",
     size: 100,
+    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
   },
 ];
 
@@ -149,69 +151,88 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
     setSelectedLeftAthletes({});
   };
   return (
-    <div>
+    <div
+    >
       <ItemPaginationBar
         label={label}
         extraActions={extraButtons}
         enableNavigationButtons={false}
       ></ItemPaginationBar>
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        sx={{ gap: "15px", width: "80%", height: "auto", margin: "2px" }}
-      >
-        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
-          <SelectTable
-            data={availableAthletes}
-            columns={availableColumns}
-            selection={selectedRightAthletes}
-            rowSelection={selectedRightAthletes}
-            setRowSelection={setSelectedRightAthletes}
-            notRecordsMessage={"No athletes available."}
-          />
-        </Box>
-
-        <Box display="flex" flexDirection="column" alignItems="center">
-          <MyIconButton
-            onClick={onRightSelected}
-            disabled={Object.keys(selectedRightAthletes).length === 0}
+      {errorOnLoading ? (
+        <>
+          <Stack
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+              width: "300px",
+              margin: "auto",
+            }}
           >
-            <RightIcon />
-          </MyIconButton>
-
-          <MyIconButton
-            onClick={onRightAll}
-            disabled={availableAthletes.length === 0}
+            <AlertBox type={typeAlertLoading} message={messageOnLoading} />
+          </Stack>
+        </>
+      ) : (
+        <>
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            sx={{ gap: "25px", width: "100%", height: "auto", margin: "2px" }}
           >
-            <RightAllIcon />
-          </MyIconButton>
+            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+              <SelectTable
+                data={availableAthletes}
+                columns={availableColumns}
+                selection={selectedRightAthletes}
+                rowSelection={selectedRightAthletes}
+                setRowSelection={setSelectedRightAthletes}
+                notRecordsMessage={"No athletes available."}
+              />
+            </Box>
 
-          <MyIconButton
-            onClick={onLeftAll}
-            disabled={selectedAthletes.length === 0}
-          >
-            <LeftAllIcon />
-          </MyIconButton>
+            <Box display="flex" flexDirection="column" alignItems="center">
+              <MyIconButton
+                onClick={onRightSelected}
+                disabled={Object.keys(selectedRightAthletes).length === 0}
+              >
+                <RightIcon />
+              </MyIconButton>
 
-          <MyIconButton
-            onClick={onLeftSelected}
-            disabled={Object.keys(selectedLeftAthletes).length === 0}
-          >
-            <LeftIcon />
-          </MyIconButton>
-        </Box>
+              <MyIconButton
+                onClick={onRightAll}
+                disabled={availableAthletes.length === 0}
+              >
+                <RightAllIcon />
+              </MyIconButton>
 
-        <Box flex="1" sx={{ maxWidth: "40%", flexGrow: 1 }}>
-          <SelectTable
-            data={selectedAthletes}
-            columns={selectedColumns}
-            rowSelection={selectedLeftAthletes}
-            setRowSelection={setSelectedLeftAthletes}
-            notRecordsMessage={"No athletes selected."}
-          />
-        </Box>
-      </Box>
+              <MyIconButton
+                onClick={onLeftAll}
+                disabled={selectedAthletes.length === 0}
+              >
+                <LeftAllIcon />
+              </MyIconButton>
+
+              <MyIconButton
+                onClick={onLeftSelected}
+                disabled={Object.keys(selectedLeftAthletes).length === 0}
+              >
+                <LeftIcon />
+              </MyIconButton>
+            </Box>
+
+            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+              <SelectTable
+                data={selectedAthletes}
+                columns={selectedColumns}
+                rowSelection={selectedLeftAthletes}
+                setRowSelection={setSelectedLeftAthletes}
+                notRecordsMessage={"No athletes selected."}
+              />
+            </Box>
+          </Box>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/GenerateHeats/SelectAthlete.jsx
+++ b/frontend/src/GenerateHeats/SelectAthlete.jsx
@@ -19,12 +19,12 @@ import {
 const availableColumns = [
   {
     accessorKey: "athlete_full_name",
-    header: "Available athletes",
+    header: "Available Athletes",
     size: 150,
   },
   {
     accessorKey: "seed_time",
-    header: "Seed time",
+    header: "Seed Time",
     size: 100,
     Cell: ({ cell }) => formatSeedTime(cell.getValue()),
   },
@@ -33,12 +33,12 @@ const availableColumns = [
 const selectedColumns = [
   {
     accessorKey: "athlete_full_name",
-    header: "Selected athletes",
+    header: "Selected Athletes",
     size: 150,
   },
   {
     accessorKey: "seed_time",
-    header: "Seed time",
+    header: "Seed Time",
     size: 100,
     Cell: ({ cell }) => formatSeedTime(cell.getValue()),
   },

--- a/frontend/src/GenerateHeats/SelectAthlete.jsx
+++ b/frontend/src/GenerateHeats/SelectAthlete.jsx
@@ -51,6 +51,9 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
   const [selectedLeftAthletes, setSelectedLeftAthletes] = useState({});
   const [errorOnLoading, setErrorOnLoading] = useState(false);
 
+  const [availableSearchTerm, setAvailableSearchTerm] = useState("");
+  const [selectedSearchTerm, setSelectedSearchTerm] = useState("");
+
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading
     ? "Data upload failed. Please try again!"
@@ -94,7 +97,13 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
     },
   ];
 
+  const handleClearSearch = () => {
+    setAvailableSearchTerm(""); 
+    setSelectedSearchTerm("");
+  };
+
   const onRightSelected = () => {
+    handleClearSearch();
     const athletesToMove = availableAthletes.filter(
       (item) => item.id in selectedRightAthletes
     );
@@ -113,6 +122,7 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
   };
 
   const onRightAll = () => {
+    handleClearSearch();
     setSelectedAthletes((prevSelectedAthletes) => {
       const allAthletes = [...prevSelectedAthletes, ...availableAthletes];
       return allAthletes.sort((a, b) =>
@@ -125,6 +135,7 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
   };
 
   const onLeftAll = () => {
+    handleClearSearch();
     setAvailableAthletes((prevAvailableAthletes) => {
       const allAthletes = [...prevAvailableAthletes, ...selectedAthletes];
       return allAthletes.sort((a, b) =>
@@ -137,6 +148,7 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
   };
 
   const onLeftSelected = () => {
+    handleClearSearch();
     const athletesToMove = selectedAthletes.filter(
       (item) => item.id in selectedLeftAthletes
     );
@@ -188,6 +200,8 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
                 rowSelection={selectedRightAthletes}
                 setRowSelection={setSelectedRightAthletes}
                 notRecordsMessage={"No athletes available."}
+                searchTerm={availableSearchTerm}
+                setSearchTerm={setAvailableSearchTerm}
               />
             </Box>
 
@@ -228,6 +242,8 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
                 rowSelection={selectedLeftAthletes}
                 setRowSelection={setSelectedLeftAthletes}
                 notRecordsMessage={"No athletes selected."}
+                searchTerm={selectedSearchTerm}
+                setSearchTerm={setSelectedSearchTerm}
               />
             </Box>
           </Box>

--- a/frontend/src/GenerateHeats/SelectAthlete.jsx
+++ b/frontend/src/GenerateHeats/SelectAthlete.jsx
@@ -85,6 +85,7 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
       label: "Confirm seed times",
       icon: <TimeIcon />,
       onClick: handleConfirmSeedTime,
+      disabled: selectedAthletes.length === 0,
     },
     {
       label: "Back to events",
@@ -151,8 +152,7 @@ const SelectAthlete = ({ eventName, eventId, onBack }) => {
     setSelectedLeftAthletes({});
   };
   return (
-    <div
-    >
+    <div>
       <ItemPaginationBar
         label={label}
         extraActions={extraButtons}

--- a/frontend/src/components/Common/SelectTable.jsx
+++ b/frontend/src/components/Common/SelectTable.jsx
@@ -10,6 +10,8 @@ const SelectTable = ({
   rowSelection,
   setRowSelection,
   notRecordsMessage,
+  searchTerm,
+  setSearchTerm,
 }) => {
   const theme = useTheme();
   const table = useMaterialReactTable({
@@ -36,10 +38,11 @@ const SelectTable = ({
     },
     getRowId: (originalRow) => originalRow.id, // Use 'id' as the unique identifier for rows
     onRowSelectionChange: setRowSelection, // Sync row selection state with parent component
-    state: { rowSelection }, // Pass the current row selection state to the table
+    state: { rowSelection, globalFilter: searchTerm }, // Pass the current row selection state to the table
     enableRowVirtualization: true, // Allow vertical scrolling for rows
     enableSorting: false,
     initialState: { density: "compact", showGlobalFilter: true }, // Show search input (GlobalFilter)
+    onGlobalFilterChange: setSearchTerm,
     enableTopToolbar: true,
     enableToolbarInternalActions: false,
     positionToolbarAlertBanner: "bottom", // Display an alert banner at the bottom with selection info

--- a/frontend/src/utils/helperFunctions.js
+++ b/frontend/src/utils/helperFunctions.js
@@ -1,0 +1,14 @@
+export function formatSeedTime(seedTime){
+    if (!seedTime) return null;
+    if (seedTime === "NT") return "NT";
+    const timeParts = seedTime.split(":");
+    const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
+    if (timeParts[0] !== "00") {
+      return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
+    }
+    if (timeParts[1] !== "00") {
+      const minutes = parseInt(timeParts[1], 10);
+      return `${minutes}:${secondsAndMillis}`;
+    }
+    return `${secondsAndMillis}`;
+  };


### PR DESCRIPTION
This PR address issue #131 

**Note: This PR depends on PR #141** 

### Implementation

1. New Files/Features

- **frontend/src/utils/helperFunctions.js**

  -  A new `helperFunctions` file has been added to the `utils` folder to contain auxiliary functions.
  -  The `formatSeedTime` function has been moved to this file for better organization and reusability.

- **frontend/src/GenerateHeats/SelectAthlete.jsx**
  
  - This is the main component introduced in this PR.
  - It fetches available athletes for a given event and displays them in a `SelectTable`. Users can select and move athletes to another `SelectTable` for participation in the event.
  - The `itemNavegationBar` on this component includes:
    - A button to navigate back to the list of events.
    - A button to `Confirm Seed Time` (second step in the heat generation process).
  - The buttons used to move athletes between tables also clear the search filters in each `SelectTable` when clicked.

2. Updates to Existing Components:

- frontend/src/Event/MeetEventDisplay.jsx
  - Added logic to render the `SelectAthlete` component when the "Generate Heat" action is clicked on a row.
  - Introduced `handleGenerateButton`, which is passed as a prop to `EventDetails`, to manage the `Generate Heats` button's behavior within that component.

- frontend/src/Event/EventDetails.jsx
  - Added a new `onGenerate` prop to handle heat generation. This prop is utilized by the generate button shown in the alert box when an event has no heats.
  - The `formatSeedTime` function has been removed from this file and is now imported from `helperFunctions`.
  
- frontend/src/components/Common/SelectTable.jsx
  - Added `searchTerm` and `setSearchTerm` as new props. These are used to reset the search filters from the `SelectAthlete` component when athletes are moved between tables. 

UI Preview

- The `Confirm Seed Time` button is **disabled** when no athlete has been selected:
![image](https://github.com/user-attachments/assets/0552734e-fdb9-4bdf-a365-2e755fd8394a)

- The `Confirm Seed Time` button is **enabled** when at least one athlete has been selected:
![image](https://github.com/user-attachments/assets/7325d97e-899d-4d30-94e5-b705ade1da57)
 

 