### PR TITLE
BE- GenerateHeatSerializar update

### DIFF
--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -1,7 +1,6 @@
-from api.models import Athlete, Heat, Group
+from api.models import Athlete, Heat
 from rest_framework import serializers
 from django.db import transaction
-from rest_framework.exceptions import ValidationError
 from api.CustomField import HeatDurationField
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 import math

--- a/backend/api/serializers/GenerateHeatSerializer.py
+++ b/backend/api/serializers/GenerateHeatSerializer.py
@@ -8,7 +8,7 @@ import math
 
 
 class AthleteSeedSerializer(serializers.Serializer):
-    athlete = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
+    id = serializers.PrimaryKeyRelatedField(queryset=Athlete.objects.all())
     seed_time = HeatDurationField()
 
 @extend_schema_serializer(
@@ -18,15 +18,15 @@ class AthleteSeedSerializer(serializers.Serializer):
             value={
                 "athletes": [
                     {
-                        "athlete": 1,
+                        "id": 1,
                         "seed_time": "45.00"
                     },
                     {
-                        "athlete": 2,
+                        "id": 2,
                         "seed_time": "26.09"
                     },
                     {
-                        "athlete": 3,
+                        "id": 3,
                         "seed_time": "NT"
                     }
                 ]
@@ -39,7 +39,7 @@ class GenerateHeatSerializer(serializers.Serializer):
     athletes = AthleteSeedSerializer(many=True)
 
     def validate_athletes(self, value):
-        athlete_ids = [athlete['athlete'].id for athlete in value]
+        athlete_ids = [athlete['id'].id for athlete in value]
         if len(athlete_ids) != len(set(athlete_ids)):
             raise serializers.ValidationError("Athletes must not be repeated.")
         return value
@@ -62,7 +62,7 @@ class GenerateHeatSerializer(serializers.Serializer):
                 num_lane = self.calculate_lane_num(i,num_lanes)
                 Heat.objects.create(
                     event = event_instance,
-                    athlete = current_heat_athletes[i - num_empty_athletes_current_heat]["athlete"],
+                    athlete = current_heat_athletes[i - num_empty_athletes_current_heat]["id"],
                     lane_num = num_lane,
                     seed_time = current_heat_athletes[i - num_empty_athletes_current_heat]["seed_time"],
 

--- a/backend/api/views/HeatView.py
+++ b/backend/api/views/HeatView.py
@@ -100,7 +100,7 @@ class HeatBatchView(APIView):
             athletes_data = request.data.get('athletes', [])
             queryset = self.get_queryset(group_instance.id)
             queryset_athlete_ids = set(queryset.values_list('id', flat=True))
-            request_athlete_ids = {athlete['athlete'] for athlete in athletes_data}
+            request_athlete_ids = {athlete['id'] for athlete in athletes_data}
             if not request_athlete_ids.issubset(queryset_athlete_ids):
                 return Response({'error': 'One or more athletes are not part of the specified group for the event.'}, status=status.HTTP_400_BAD_REQUEST)
             serializer.save()

--- a/backend/api/views/HeatView.py
+++ b/backend/api/views/HeatView.py
@@ -1,5 +1,4 @@
 from rest_framework.views import APIView
-from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
 from api.models import MeetEvent, Heat, Group, Athlete
@@ -10,7 +9,6 @@ from drf_spectacular.utils import extend_schema
 from django.db import transaction
 from django.db.models import F, Value, Func, IntegerField
 from django.utils import timezone
-from django.db.models import Max
 
 
 @extend_schema(tags=['Heat'])


### PR DESCRIPTION
This PR addresses issue #139 

Implementation

1. `backend/api/serializers/GenerateHeatSerializer.py`
`athlete` field was renamed `id` on `AthleteSeedSerializer`.

2. `backend/api/views/HeatView.py`
`athlete` field was renamed `id`  on POST method.