### PR TITLE
FE Disable Create Button on SwimMeetForm When Form is Not Valid

### DIFF
--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -21,7 +21,7 @@ const AddSwimMeet = () => {
     handleSubmit,
     control,
     reset,
-    formState: { isDirty },
+    formState: { isDirty, isValid },
   } = useForm({
     defaultValues: {
       name: "",
@@ -157,6 +157,7 @@ const AddSwimMeet = () => {
               control={control}
               handleCancel={handleCancel}
               options={sites}
+              isValid={isValid}
             />
           </Stack>
         </Stack>

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -5,6 +5,7 @@ import MyButton from "../components/FormElements/MyButton.jsx";
 import MyDatePicker from "../components/FormElements/MyDatePicker.jsx";
 import MyTimePicker from "../components/FormElements/MyTimePicker.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
+import dayjs from "dayjs";
 
 const SwimMeetForm = ({
   handleSubmit,
@@ -30,7 +31,13 @@ const SwimMeetForm = ({
             name={"date"}
             control={control}
             disablePast={true}
-            rules={{ required: "Date is required" }}
+            rules={{ required: "Date is required",
+              validate: (value) => {
+                return value && dayjs(value).isValid()
+                  ? true
+                  : "Invalid date format";
+              },
+             }}
           />
         </Box>
         <Box className={"itemBox"}>
@@ -38,7 +45,14 @@ const SwimMeetForm = ({
             label={"Time"}
             name={"time"}
             control={control}
-            rules={{ required: "Time is required" }}
+            rules={{
+              required: "Time is required",
+              validate: (value) => {
+                return value && dayjs(value).isValid()
+                  ? true
+                  : "Invalid time format";
+              },
+            }}
           />
         </Box>
         <Box className={"itemBox"}>
@@ -47,7 +61,9 @@ const SwimMeetForm = ({
             name={"site"}
             control={control}
             options={options}
-            rules={{ required: "Site is required" }}
+            rules={{
+              required: "Site is required",
+            }}
           />
         </Box>
       </Stack>

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -33,9 +33,10 @@ const SwimMeetForm = ({
             disablePast={true}
             rules={{ required: "Date is required",
               validate: (value) => {
-                return value && dayjs(value).isValid()
-                  ? true
-                  : "Invalid date format";
+                if (!dayjs(value).isValid()) return "Invalid date";
+                if (dayjs(value).isBefore(dayjs()))
+                  return "Date cannot be in the past";
+                return true;
               },
              }}
           />
@@ -48,9 +49,8 @@ const SwimMeetForm = ({
             rules={{
               required: "Time is required",
               validate: (value) => {
-                return value && dayjs(value).isValid()
-                  ? true
-                  : "Invalid time format";
+                if (!dayjs(value).isValid()) return "Invalid time";
+                return true;
               },
             }}
           />

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -34,7 +34,7 @@ const SwimMeetForm = ({
             rules={{ required: "Date is required",
               validate: (value) => {
                 if (!dayjs(value).isValid()) return "Invalid date";
-                if (dayjs(value).isBefore(dayjs()))
+                if (dayjs(value).startOf('day').isBefore(dayjs().startOf('day')))
                   return "Date cannot be in the past";
                 return true;
               },

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -1,12 +1,18 @@
 import "../App.css";
-import { Box, Stack} from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import MyTextField from "../components/FormElements/MyTextField.jsx";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import MyDatePicker from "../components/FormElements/MyDatePicker.jsx";
 import MyTimePicker from "../components/FormElements/MyTimePicker.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
 
-const SwimMeetForm = ({ handleSubmit, control, handleCancel, options }) => {
+const SwimMeetForm = ({
+  handleSubmit,
+  control,
+  handleCancel,
+  options,
+  isValid,
+}) => {
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
       <Stack>
@@ -46,7 +52,12 @@ const SwimMeetForm = ({ handleSubmit, control, handleCancel, options }) => {
         </Box>
       </Stack>
       <Stack className={"itemBox"}>
-        <MyButton key={"create"} label={"Create"} type={"submit"} />
+        <MyButton
+          key={"create"}
+          label={"Create"}
+          type={"submit"}
+          disabled={!isValid}
+        />
         <Box sx={{ marginTop: 2 }}></Box>
         <MyButton
           key={"cancel"}

--- a/frontend/src/components/FormElements/MyTextField.jsx
+++ b/frontend/src/components/FormElements/MyTextField.jsx
@@ -21,6 +21,9 @@ const MyTextField = (props) => {
           error={!!error}
           helperText={error?.message}
           sx={{ minWidth: 250 }}
+          InputLabelProps={{
+            shrink: true,
+          }}
         />
       )}
     />


### PR DESCRIPTION
This PR addresses issue #144. 

### Description

This update ensures that the `Create` button on the `SwimMeetForm` is disabled when the form is invalid, improving user experience and input validation.

Implementation

1. frontend/src/SwimMeet/AddSwimMeet.jsx

- Collected `isValid` status from `useForm`, then passed it as a prop to `SwimMeetForm`.

2. frontend/src/SwimMeet/SwimMeetForm.jsx

- Added validation for `MyDatePicker` and `MyTimePicker` components:
  - `MyDatePicker`:
     - Ensures the date is valid.
     - Ensures the date is not in the past.
  - `MyTimePicker`: 
    - Ensures the time input is valid.
- The "Create" button is now enabled or disabled based on the `isValid` prop.

UI Preview

- Create Button Disabled on Form Load: The "Create" button is initially disabled because the Swim Meet Name field is empty.
![image](https://github.com/user-attachments/assets/563bc28d-1b0d-498d-bb05-74b8c83ac998)

- Invalid Date: The form shows an error when an invalid date is entered.
![image](https://github.com/user-attachments/assets/8e7d5fc7-18a1-4e82-a5b7-88b3a4906b08)

- Invalid Time: Displays an error for an invalid time input.
![image](https://github.com/user-attachments/assets/a461a463-179d-4bcf-b418-cb99dc03cbb4)

- Date on the past: Shows an error when a date in the past is selected.
![image](https://github.com/user-attachments/assets/a1a88268-65b0-4f17-bb4c-aa77673a25f2)

- Form valid: All fields are valid, enabling the "Create" button.
![image](https://github.com/user-attachments/assets/a9f492ec-5615-482c-8056-882a788917e4)
