### PR TITLE
FE - Step 3: Generate Heats actions

### DIFF
--- a/backend/api/views/MeetEventView.py
+++ b/backend/api/views/MeetEventView.py
@@ -69,8 +69,9 @@ class MeetEventView(APIView):
         }
         serializer = MeetEventSerializer(data=event_data)
         if serializer.is_valid():
-            serializer.save()
-            return Response({'success': 'Event added to the swim meet'}, status=status.HTTP_200_OK)
+            created_event = serializer.save()
+            event_serializer = MeetEventSerializer(created_event)
+            return Response(event_serializer.data, status=status.HTTP_200_OK)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     

--- a/frontend/src/Event/AddEvent.jsx
+++ b/frontend/src/Event/AddEvent.jsx
@@ -7,9 +7,8 @@ import { SmmApi } from "../SmmApi.jsx";
 import AddEventForm from "./AddEventForm.jsx";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { Build as BuildIcon } from "@mui/icons-material";
-import Title from "../components/Common/Title.jsx";
 
-const AddEvent = ({ onBack, onCreateHeats, setTargetEvent }) => {
+const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
   const { meetId } = useParams();
   const [error, setError] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
@@ -96,7 +95,8 @@ const AddEvent = ({ onBack, onCreateHeats, setTargetEvent }) => {
   const submission = async (data) => {
     try {
       const response = await SmmApi.createEvent(meetId, data);
-      setTargetEvent(response.data);
+      //setTargetEvent(response.data);
+      onCreateEvent();
       setError(false);
     } catch (error) {
       if (error.response && error.response.status === 400) {

--- a/frontend/src/Event/AddEvent.jsx
+++ b/frontend/src/Event/AddEvent.jsx
@@ -1,12 +1,12 @@
-import "../App.css";
+import { Build as BuildIcon } from "@mui/icons-material";
 import { Stack } from "@mui/material";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useState, useEffect, useMemo } from "react";
-import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
+import "../App.css";
+import AlertBox from "../components/Common/AlertBox.jsx";
 import { SmmApi } from "../SmmApi.jsx";
 import AddEventForm from "./AddEventForm.jsx";
-import AlertBox from "../components/Common/AlertBox.jsx";
-import { Build as BuildIcon } from "@mui/icons-material";
 
 const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
   const { meetId } = useParams();
@@ -95,7 +95,6 @@ const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
   const submission = async (data) => {
     try {
       const response = await SmmApi.createEvent(meetId, data);
-      //setTargetEvent(response.data);
       onCreateEvent();
       setError(false);
     } catch (error) {

--- a/frontend/src/Event/AddEvent.jsx
+++ b/frontend/src/Event/AddEvent.jsx
@@ -9,7 +9,7 @@ import AlertBox from "../components/Common/AlertBox.jsx";
 import { Build as BuildIcon } from "@mui/icons-material";
 import Title from "../components/Common/Title.jsx";
 
-const AddEvent = () => {
+const AddEvent = ({onBack}) => {
   const { meetId } = useParams();
   const [error, setError] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
@@ -87,9 +87,6 @@ const AddEvent = () => {
     };
   }, []);
 
-  const handleCancel = () => {
-    navigate(`/swim-meet/${meetId}/events`, { state: meetData });
-  };
 
   const handleAddHeats = () => {
     //Change it to add heats for the new event
@@ -103,7 +100,6 @@ const AddEvent = () => {
   let actionButtons = error ? [] : actionButtonsSuccess;
 
   const submission = async (data) => {
-    setSubmitted(true);
     try {
       const response = await SmmApi.createEvent(meetId, data);
       setLastEventId(response.data.id);
@@ -118,8 +114,8 @@ const AddEvent = () => {
           "Unable to create the Event, an unexpected error occurred. Please try again!"
         );
       }
-      console.log(error);
     }
+    setSubmitted(true);
     reset({
       group: groups[0]?.id || "",
       event_type: eventTypes[0]?.id || "",
@@ -143,7 +139,6 @@ const AddEvent = () => {
   } else {
     return (
       <div>
-        <Title data={meetData} fields={["name", "date", "site_name"]} />
         <Stack alignItems="center" justifyContent="space-between">
           <Stack alignItems="center" justifyContent="space-between">
             {submitted && (
@@ -158,7 +153,7 @@ const AddEvent = () => {
             <AddEventForm
               handleSubmit={handleSubmit(submission)}
               control={control}
-              handleCancel={handleCancel}
+              handleCancel={onBack}
               options={{ groups, eventTypes }}
             />
           </Stack>

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -47,8 +47,11 @@ const EventDetails = ({
         }
       } catch (error) {
         setErrorOnLoading(true);
-      } finally {
-        setLoading(false);
+      }finally {
+        setTimeout(() => {
+          setLoading(false);
+        }, 100);
+        
       }
     }
     fetching();
@@ -56,6 +59,7 @@ const EventDetails = ({
       ignore = true;
     };
   }, [eventId]);
+
 
   //What is needed for the itemPaginationBar
   const label = "Event " + eventName;

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -151,7 +151,7 @@ const EventDetails = ({
   //Need for Generate heats AlertBox
 
   let actionButtonsNoHeats = [
-    { label: "heats", onClick: onGenerate, icon: <BuildIcon /> },
+    { label: "Create Heats", onClick: onGenerate, icon: <BuildIcon /> },
   ];
 
   return (
@@ -191,14 +191,14 @@ const EventDetails = ({
               display: "flex",
               flexDirection: "column",
               gap: "16px",
-              width: "300px",
+              width: "500px",
               margin: "auto",
             }}
           >
             <AlertBox
               type="info"
               message="This event has no heats yet."
-              actionButtons={actionButtonsNoHeats}
+              actionButtons={actionButtonsNoHeats}         
             />
           </Stack>
         </>

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect } from "react";
+import { ContentPaste as BackIcon, Build as BuildIcon } from "@mui/icons-material";
+import { CircularProgress, Stack } from "@mui/material";
+import React, { useEffect, useState } from "react";
 import { SmmApi } from "../SmmApi.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import ExpandableTable from "../components/Common/ExpandableTable";
 import ItemPaginationBar from "../components/Common/ItemPaginationBar";
 import TabPanel from "../components/Common/TabPanel";
-import ExpandableTable from "../components/Common/ExpandableTable";
-import { ContentPaste as BackIcon } from "@mui/icons-material";
-import AlertBox from "../components/Common/AlertBox.jsx";
-import { Build as BuildIcon } from "@mui/icons-material";
-import { Stack, CircularProgress } from "@mui/material";
 import { formatSeedTime } from "../utils/helperFunctions.js";
 
 const EventDetails = ({

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -6,7 +6,7 @@ import ExpandableTable from "../components/Common/ExpandableTable";
 import { ContentPaste as BackIcon } from "@mui/icons-material";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { Build as BuildIcon } from "@mui/icons-material";
-import { Stack } from "@mui/material";
+import { Stack, CircularProgress } from "@mui/material";
 import { formatSeedTime } from "../utils/helperFunctions.js";
 
 const EventDetails = ({
@@ -22,6 +22,7 @@ const EventDetails = ({
   const [numHeats, setNumHeats] = useState(null);
   const [heatData, setHeatData] = useState([]);
   const [laneData, setLaneData] = useState([]);
+  const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
   const [selectedTab, setSelectedTab] = useState(0);
 
@@ -34,6 +35,7 @@ const EventDetails = ({
   useEffect(() => {
     let ignore = false;
     async function fetching() {
+      setLoading(true);
       try {
         const heat_json = await SmmApi.getEventHeats(eventId);
         const lane_json = await SmmApi.getEventLanes(eventId);
@@ -45,6 +47,8 @@ const EventDetails = ({
         }
       } catch (error) {
         setErrorOnLoading(true);
+      } finally {
+        setLoading(false);
       }
     }
     fetching();
@@ -164,7 +168,15 @@ const EventDetails = ({
         disableNext={disableNext}
         extraActions={extraButtons}
       ></ItemPaginationBar>
-      {errorOnLoading ? (
+      {loading ? (
+        <Stack
+          alignItems="center"
+          justifyContent="center"
+          style={{ height: "100px" }}
+        >
+          <CircularProgress />
+        </Stack>
+      ) : errorOnLoading ? (
         <>
           <Stack
             style={{
@@ -198,7 +210,7 @@ const EventDetails = ({
             <AlertBox
               type="info"
               message="This event has no heats yet."
-              actionButtons={actionButtonsNoHeats}         
+              actionButtons={actionButtonsNoHeats}
             />
           </Stack>
         </>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -90,15 +90,15 @@ const MeetEventDisplay = () => {
       name: "Heats Details",
       icon: <HeatIcon />,
       onClick: handleDetailsClick,
-      tip: "Go to heats",
+      tip: "Go to Heats",
       visible: (row) => row.original.total_num_heats > 0,
     },
-    {
-      name: "Delete",
-      icon: <DeleteIcon />,
-      onClick: handleDeleteClick,
-      tip: "Delete",
-    },
+    // {
+    //   name: "Delete",
+    //   icon: <DeleteIcon />,
+    //   onClick: handleDeleteClick,
+    //   tip: "Delete",
+    // },
     {
       name: "Ranking",
       icon: <RankingIcon />,

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -80,10 +80,10 @@ const MeetEventDisplay = () => {
 
   const actions = [
     {
-      name: "Generate Heats",
+      name: "Create Heats",
       icon: <BuildIcon />,
       onClick: handleGenerateClick,
-      tip: "Generate heats",
+      tip: "Go to Create Heats",
       visible: (row) => row.original.total_num_heats === 0,
     },
     {

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -15,8 +15,8 @@ import GenericTable from "../components/Common/GenericTable.jsx";
 import PaginationBar from "../components/Common/PaginationBar.jsx";
 import Title from "../components/Common/Title.jsx";
 import MyButton from "../components/FormElements/MyButton.jsx";
-import EventDetails from "./EventDetails.jsx";
 import AddEvent from "./AddEvent.jsx";
+import EventDetails from "./EventDetails.jsx";
 
 const columns = [
   {

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -47,6 +47,7 @@ const MeetEventDisplay = () => {
 
   //AddNew states
   const [showAddEvent, setShowAddEvent] = useState(false);
+  const [targetEvent, setTargetEvent] = useState(null);
 
   //GenerateHeats states
   const [reloadEventDataTrigger, setReloadEventDataTrigger] = useState(0);
@@ -151,7 +152,7 @@ const MeetEventDisplay = () => {
     setShowEventDetails(false);
     setShowGenerateHeats(false);
     setShowAddEvent(false);
-    setSelectedEventIndex(null);  
+    setSelectedEventIndex(null);
   };
 
   const handleGenerateButton = () => {
@@ -193,29 +194,22 @@ const MeetEventDisplay = () => {
     if (index === -1) {
       setShowGenerateHeats(false);
       setShowEventDetails(false);
+      setShowAddEvent(false);
       setSelectedEventIndex(null);
     } else {
       setShowGenerateHeats(false);
       setSelectedEventIndex(index);
+      setShowAddEvent(false);
       setShowEventDetails(true);
     }
   };
 
-  // const handleAddHeatsToNewEvent = (eventId) => {
-  //   let index = -1;
-  //   let currentOffset = 0;
-  //   while (index === -1){
-  //     setOffset(currentOffset);
-  //     const index = eventData.findIndex((item) => item.id === eventId);
-  //     if (index != -1){
-  //     setSelectedEventIndex(index);
-  //     setShowGenerateHeats(true);
-  //     setShowEventDetails(false);
-  //     break;
-  //     }
-  //     currentOffset +=limit;
-  //   }
-  // };
+  const handleAddHeatsToNewEvent = () => {
+    setSelectedEventIndex(null);
+    setShowAddEvent(false);
+    setShowEventDetails(false);
+    setShowGenerateHeats(true);
+  };
 
   const isFirstEvent = page === 0 && selectedEventIndex === 0;
   const isLastEvent = offset + selectedEventIndex + 1 >= count;
@@ -256,8 +250,19 @@ const MeetEventDisplay = () => {
             onBack={handleBackToEvents}
             onProcessCompletion={handleGenerateHeatProcessCompletion}
           />
+        ) : showGenerateHeats && targetEvent ? (
+          <GenerateHeats
+            eventName={targetEvent.name}
+            eventId={targetEvent.id}
+            onBack={handleBackToEvents}
+            onProcessCompletion={handleGenerateHeatProcessCompletion}
+          />
         ) : showAddEvent ? (
-          <AddEvent onBack={handleBackToEvents} />
+          <AddEvent
+            onBack={handleBackToEvents}
+            onCreateHeats={handleAddHeatsToNewEvent}
+            setTargetEvent={setTargetEvent}
+          />
         ) : (
           <>
             <Stack

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -16,6 +16,7 @@ import PaginationBar from "../components/Common/PaginationBar.jsx";
 import Title from "../components/Common/Title.jsx";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import EventDetails from "./EventDetails.jsx";
+import AddEvent from "./AddEvent.jsx";
 
 const columns = [
   {
@@ -44,8 +45,11 @@ const MeetEventDisplay = () => {
   const [selectedEventIndex, setSelectedEventIndex] = useState(null);
   const [navegationDirection, setNavegationDirection] = useState(null);
 
+  //AddNew states
+  const [showAddEvent, setShowAddEvent] = useState(false);
+
   //GenerateHeats states
-  const [generateHeatTrigger, setGenerateHeatTrigger] = useState(0);
+  const [reloadEventDataTrigger, setReloadEventDataTrigger] = useState(0);
 
   //Pagination States
   const [count, setCount] = useState(0);
@@ -60,14 +64,16 @@ const MeetEventDisplay = () => {
 
   const handleGenerateClick = (id) => {
     setSelectedEventIndex(Number(id));
-    setShowGenerateHeats(true);
+    setShowAddEvent(false);
     setShowEventDetails(false);
+    setShowGenerateHeats(true);
   };
 
   const handleDetailsClick = (id) => {
     setSelectedEventIndex(Number(id));
-    setShowEventDetails(true);
+    setShowAddEvent(false);
     setShowGenerateHeats(false);
+    setShowEventDetails(true);
   };
 
   const handleDeleteClick = (id) => {
@@ -131,20 +137,26 @@ const MeetEventDisplay = () => {
     return () => {
       ignore = true;
     };
-  }, [offset, limit, generateHeatTrigger]);
+  }, [offset, limit, reloadEventDataTrigger]);
 
   const handleAddNew = () => {
-    navigate(`/add-event/${meetId}`, { state: meetData });
-  };
-
-  const handleBackToEvents = () => {
     setShowEventDetails(false);
     setShowGenerateHeats(false);
     setSelectedEventIndex(null);
+    setShowAddEvent(true);
+  };
+
+  const handleBackToEvents = () => {
+    setReloadEventDataTrigger((prev) => prev + 1);
+    setShowEventDetails(false);
+    setShowGenerateHeats(false);
+    setShowAddEvent(false);
+    setSelectedEventIndex(null);  
   };
 
   const handleGenerateButton = () => {
     setShowEventDetails(false);
+    setShowAddEvent(false);
     setShowGenerateHeats(true);
   };
 
@@ -177,7 +189,7 @@ const MeetEventDisplay = () => {
 
   const handleGenerateHeatProcessCompletion = (eventId) => {
     const index = eventData.findIndex((item) => item.id === eventId);
-    setGenerateHeatTrigger((prev) => prev + 1);
+    setReloadEventDataTrigger((prev) => prev + 1);
     if (index === -1) {
       setShowGenerateHeats(false);
       setShowEventDetails(false);
@@ -188,6 +200,22 @@ const MeetEventDisplay = () => {
       setShowEventDetails(true);
     }
   };
+
+  // const handleAddHeatsToNewEvent = (eventId) => {
+  //   let index = -1;
+  //   let currentOffset = 0;
+  //   while (index === -1){
+  //     setOffset(currentOffset);
+  //     const index = eventData.findIndex((item) => item.id === eventId);
+  //     if (index != -1){
+  //     setSelectedEventIndex(index);
+  //     setShowGenerateHeats(true);
+  //     setShowEventDetails(false);
+  //     break;
+  //     }
+  //     currentOffset +=limit;
+  //   }
+  // };
 
   const isFirstEvent = page === 0 && selectedEventIndex === 0;
   const isLastEvent = offset + selectedEventIndex + 1 >= count;
@@ -226,8 +254,10 @@ const MeetEventDisplay = () => {
             eventName={eventData[selectedEventIndex].name}
             eventId={eventData[selectedEventIndex].id}
             onBack={handleBackToEvents}
-            processCompletion={handleGenerateHeatProcessCompletion}
+            onProcessCompletion={handleGenerateHeatProcessCompletion}
           />
+        ) : showAddEvent ? (
+          <AddEvent onBack={handleBackToEvents} />
         ) : (
           <>
             <Stack

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -44,6 +44,9 @@ const MeetEventDisplay = () => {
   const [selectedEventIndex, setSelectedEventIndex] = useState(null);
   const [navegationDirection, setNavegationDirection] = useState(null);
 
+  //GenerateHeats states
+  const [generateHeatTrigger, setGenerateHeatTrigger] = useState(0);
+
   //Pagination States
   const [count, setCount] = useState(0);
   const [offset, setOffset] = useState(0);
@@ -128,7 +131,7 @@ const MeetEventDisplay = () => {
     return () => {
       ignore = true;
     };
-  }, [offset, limit]);
+  }, [offset, limit, generateHeatTrigger]);
 
   const handleAddNew = () => {
     navigate(`/add-event/${meetId}`, { state: meetData });
@@ -172,6 +175,19 @@ const MeetEventDisplay = () => {
     }
   };
 
+  const handleSwitchGenerateToDetails = (eventId) => {
+    const index = eventData.findIndex((item) => item.id === eventId);
+    if (index === -1) {
+      setShowGenerateHeats(false);
+      setShowEventDetails(false);
+      setSelectedEventIndex(null);
+    } else {
+      setShowGenerateHeats(false);
+      setSelectedEventIndex(index);
+      setShowEventDetails(true);
+    }
+  };
+
   const isFirstEvent = page === 0 && selectedEventIndex === 0;
   const isLastEvent = offset + selectedEventIndex + 1 >= count;
 
@@ -210,6 +226,8 @@ const MeetEventDisplay = () => {
             eventName={eventData[selectedEventIndex].name}
             eventId={eventData[selectedEventIndex].id}
             onBack={handleBackToEvents}
+            setGenerateHeatTrigger={setGenerateHeatTrigger}
+            switchViews={handleSwitchGenerateToDetails}
           />
         ) : (
           <>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -175,8 +175,9 @@ const MeetEventDisplay = () => {
     }
   };
 
-  const handleSwitchGenerateToDetails = (eventId) => {
+  const handleGenerateHeatProcessCompletion = (eventId) => {
     const index = eventData.findIndex((item) => item.id === eventId);
+    setGenerateHeatTrigger((prev) => prev + 1);
     if (index === -1) {
       setShowGenerateHeats(false);
       setShowEventDetails(false);
@@ -221,13 +222,11 @@ const MeetEventDisplay = () => {
             disableNext={isLastEvent}
           />
         ) : showGenerateHeats && eventData[selectedEventIndex] ? (
-          //Need to change to select athletes
           <GenerateHeats
             eventName={eventData[selectedEventIndex].name}
             eventId={eventData[selectedEventIndex].id}
             onBack={handleBackToEvents}
-            setGenerateHeatTrigger={setGenerateHeatTrigger}
-            switchViews={handleSwitchGenerateToDetails}
+            processCompletion={handleGenerateHeatProcessCompletion}
           />
         ) : (
           <>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -150,8 +150,6 @@ const MeetEventDisplay = () => {
             pageToNavigate * limit,
             limit
           );
-          console.log("Page to navigate:", pageToNavigate);
-          console.log(response.results);
           const foundIndex = response.results.findIndex(
             (event) => event.id === targetEvent.id
           );
@@ -241,11 +239,11 @@ const MeetEventDisplay = () => {
 
   const handleAddHeatsToNewEvent = () => {
     setReloadEventDataTrigger((prev) => prev + 1);
-    if(selectedEventIndex){
+    if (selectedEventIndex) {
       setShowAddEvent(false);
       setShowEventDetails(false);
       setShowGenerateHeats(true);
-    } else{
+    } else {
       setShowAddEvent(false);
       setShowEventDetails(false);
       setShowGenerateHeats(false);

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -135,6 +135,7 @@ const GenerateHeats = ({
     setHeatsCreated(true);
     setTimeout(() => {
       if (heatCreationSuccessful) {
+        //This will reload the events data and switch to show the details of the given event
         setGenerateHeatTrigger((prev) => prev + 1);
         switchViews(eventId);
       }

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -85,7 +85,7 @@ const GenerateHeats = ({
   const [areAthletesSelected, setAreAthletesSelected] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [athleteToUpdate, setAthleteToUpdate] = useState({});
-  //State to manage Heat Creation
+  //State to manage Heat Creation (step 3 of process)
   const [heatsCreated, setHeatsCreated] = useState(false);
   const [errorCreateHeat, setErrorCreateHeat] = useState(false);
 

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -64,7 +64,13 @@ const confirmSeedTimeColumns = [
   },
 ];
 
-const GenerateHeats = ({ eventName, eventId, onBack }) => {
+const GenerateHeats = ({
+  eventName,
+  eventId,
+  onBack,
+  setGenerateHeatTrigger,
+  switchViews,
+}) => {
   const [availableAthletes, setAvailableAthletes] = useState([]);
   const [selectedAthletes, setSelectedAthletes] = useState([]);
   const [selectedRightAthletes, setSelectedRightAthletes] = useState({});
@@ -75,8 +81,14 @@ const GenerateHeats = ({ eventName, eventId, onBack }) => {
   const [areAthletesSelected, setAreAthletesSelected] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [athleteToUpdate, setAthleteToUpdate] = useState({});
+  const [heatsCreated, setHeatsCreated] = useState(false);
+  const [error, setError] = useState(false);
 
   const label = "Event " + eventName;
+
+  // AlertBox variables
+  let typeAlertCreateHeats = error ? "error" : "success";
+  let messageCreateHeats = error ? error : "Heats created successfully!";
 
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading
@@ -107,8 +119,27 @@ const GenerateHeats = ({ eventName, eventId, onBack }) => {
     setAreAthletesSelected(!areAthletesSelected);
   };
 
-  const handleGenerateHeats = () => {
-    console.log("Create Heats clicked!");
+  const handleGenerateHeats = async (selectedAthletes) => {
+    setError(false);
+    let heatCreationSuccessful = false;
+    try {
+      const response = await SmmApi.createHeats(eventId, {
+        athletes: selectedAthletes,
+      });
+      heatCreationSuccessful = true;
+    } catch (error) {
+      setError(
+        "Unable to Create Heats, an unexpected error occurred. Please try again!"
+      );
+    }
+    setHeatsCreated(true);
+    setTimeout(() => {
+      if (heatCreationSuccessful) {
+        setGenerateHeatTrigger((prev) => prev + 1);
+        switchViews(eventId);
+      }
+      setHeatsCreated(false);
+    }, 2000);
   };
 
   const handleEditClick = (row) => {
@@ -141,7 +172,7 @@ const GenerateHeats = ({ eventName, eventId, onBack }) => {
     {
       label: "Create Heats",
       icon: <BuildIcon />,
-      onClick: handleGenerateHeats,
+      onClick: () => handleGenerateHeats(selectedAthletes),
       visible: areAthletesSelected,
     },
     {
@@ -323,6 +354,12 @@ const GenerateHeats = ({ eventName, eventId, onBack }) => {
               athlete={selectedAthletes[athleteToUpdate]}
               onUpdate={handleUpdateSeedTime}
               onCancel={() => setIsFormOpen(false)}
+            />
+          </Dialog>
+          <Dialog open={heatsCreated} fullWidth>
+            <AlertBox
+              type={typeAlertCreateHeats}
+              message={messageCreateHeats}
             />
           </Dialog>
         </div>

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -9,7 +9,7 @@ import {
   NavigateNext as RightIcon,
   Timer as TimeIcon,
 } from "@mui/icons-material";
-import { Box, Dialog, Stack, DialogContent } from "@mui/material";
+import { Box, Dialog, DialogContent, Stack } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import "../App.css";
 import { SmmApi } from "../SmmApi.jsx";

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -71,24 +71,29 @@ const GenerateHeats = ({
   setGenerateHeatTrigger,
   switchViews,
 }) => {
+  //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
   const [selectedAthletes, setSelectedAthletes] = useState([]);
   const [selectedRightAthletes, setSelectedRightAthletes] = useState({});
   const [selectedLeftAthletes, setSelectedLeftAthletes] = useState({});
+  //State to manage loading
   const [errorOnLoading, setErrorOnLoading] = useState(false);
+  //State to manage search on selectTables
   const [availableSearchTerm, setAvailableSearchTerm] = useState("");
   const [selectedSearchTerm, setSelectedSearchTerm] = useState("");
+  //State to manage change to step 2 of process
   const [areAthletesSelected, setAreAthletesSelected] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [athleteToUpdate, setAthleteToUpdate] = useState({});
+  //State to manage Heat Creation
   const [heatsCreated, setHeatsCreated] = useState(false);
-  const [error, setError] = useState(false);
+  const [errorCreateHeat, setErrorCreateHeat] = useState(false);
 
   const label = "Event " + eventName;
 
   // AlertBox variables
-  let typeAlertCreateHeats = error ? "error" : "success";
-  let messageCreateHeats = error ? error : "Heats created successfully!";
+  let typeAlertCreateHeats = errorCreateHeat ? "error" : "success";
+  let messageCreateHeats = errorCreateHeat ? errorCreateHeat : "Heats created successfully!";
 
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading
@@ -120,7 +125,7 @@ const GenerateHeats = ({
   };
 
   const handleGenerateHeats = async (selectedAthletes) => {
-    setError(false);
+    setErrorCreateHeat(false);
     let heatCreationSuccessful = false;
     try {
       const response = await SmmApi.createHeats(eventId, {
@@ -128,7 +133,7 @@ const GenerateHeats = ({
       });
       heatCreationSuccessful = true;
     } catch (error) {
-      setError(
+      setErrorCreateHeat(
         "Unable to Create Heats, an unexpected error occurred. Please try again!"
       );
     }

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -68,8 +68,7 @@ const GenerateHeats = ({
   eventName,
   eventId,
   onBack,
-  setGenerateHeatTrigger,
-  switchViews,
+  processCompletion,
 }) => {
   //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
@@ -141,8 +140,7 @@ const GenerateHeats = ({
     setTimeout(() => {
       if (heatCreationSuccessful) {
         //This will reload the events data and switch to show the details of the given event
-        setGenerateHeatTrigger((prev) => prev + 1);
-        switchViews(eventId);
+        processCompletion(eventId);
       }
       setHeatsCreated(false);
     }, 2000);

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -68,7 +68,7 @@ const GenerateHeats = ({
   eventName,
   eventId,
   onBack,
-  processCompletion,
+  onProcessCompletion,
 }) => {
   //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
@@ -140,7 +140,7 @@ const GenerateHeats = ({
     setTimeout(() => {
       if (heatCreationSuccessful) {
         //This will reload the events data and switch to show the details of the given event
-        processCompletion(eventId);
+        onProcessCompletion(eventId);
       }
       setHeatsCreated(false);
     }, 2000);

--- a/frontend/src/GenerateHeats/GenerateHeats.jsx
+++ b/frontend/src/GenerateHeats/GenerateHeats.jsx
@@ -9,7 +9,7 @@ import {
   NavigateNext as RightIcon,
   Timer as TimeIcon,
 } from "@mui/icons-material";
-import { Box, Dialog, Stack } from "@mui/material";
+import { Box, Dialog, Stack, DialogContent } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import "../App.css";
 import { SmmApi } from "../SmmApi.jsx";
@@ -358,10 +358,12 @@ const GenerateHeats = ({
             />
           </Dialog>
           <Dialog open={heatsCreated} fullWidth>
-            <AlertBox
-              type={typeAlertCreateHeats}
-              message={messageCreateHeats}
-            />
+            <DialogContent style={{ padding: "24px" }}>
+              <AlertBox
+                type={typeAlertCreateHeats}
+                message={messageCreateHeats}
+              />
+            </DialogContent>
           </Dialog>
         </div>
       )}

--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -1,14 +1,13 @@
-import "../App.css";
-import { Box, Stack } from "@mui/material";
-import { useForm } from "react-hook-form";
-import { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
-import { SmmApi } from "../SmmApi.jsx";
-import dayjs from "dayjs";
-import SwimMeetForm from "./SwimMeetForm.jsx";
-import AlertBox from "../components/Common/AlertBox.jsx";
 import { Add as AddIcon } from "@mui/icons-material";
-import MeetEventDisplay from "../Event/MeetEventDisplay.jsx";
+import { Stack } from "@mui/material";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import "../App.css";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import { SmmApi } from "../SmmApi.jsx";
+import SwimMeetForm from "./SwimMeetForm.jsx";
 
 const AddSwimMeet = () => {
   const [error, setError] = useState(false);

--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -8,6 +8,7 @@ import dayjs from "dayjs";
 import SwimMeetForm from "./SwimMeetForm.jsx";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { Add as AddIcon } from "@mui/icons-material";
+import MeetEventDisplay from "../Event/MeetEventDisplay.jsx";
 
 const AddSwimMeet = () => {
   const [error, setError] = useState(false);
@@ -84,7 +85,9 @@ const AddSwimMeet = () => {
   };
 
   const handleAddEvents = () => {
-    navigate(`/add-event/${lastSwimMeetData.id}`, { state: lastSwimMeetData });
+    navigate(`/swim-meet/${lastSwimMeetData.id}/events`, {
+      state: { showAddEvent: true, meetData: lastSwimMeetData },
+    });
   };
 
   let actionButtonsSuccess = [

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -1,20 +1,20 @@
-import { useMemo, useState, useEffect } from "react";
-import dayjs from "dayjs";
-import { SmmApi } from "../SmmApi";
-import GenericTable from "../components/Common/GenericTable";
-import SearchBar from "../components/Common/SearchBar";
-import PaginationBar from "../components/Common/PaginationBar";
 import {
-  Edit as EditIcon,
+  Add as AddIcon,
   Delete as DeleteIcon,
   ContentPaste as DetailsIcon,
+  Edit as EditIcon,
   EmojiEvents as RankingIcon,
-  Add as AddIcon,
 } from "@mui/icons-material";
-import MyButton from "../components/FormElements/MyButton";
-import { Stack, Box } from "@mui/material";
+import { Box, Stack } from "@mui/material";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { SmmApi } from "../SmmApi";
 import AlertBox from "../components/Common/AlertBox.jsx";
+import GenericTable from "../components/Common/GenericTable";
+import PaginationBar from "../components/Common/PaginationBar";
+import SearchBar from "../components/Common/SearchBar";
+import MyButton from "../components/FormElements/MyButton";
 
 const columns = [
   {

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -58,7 +58,9 @@ const SwimMeetDisplay = () => {
     : "";
 
   const handleDetailsClick = (id) => {
-    navigate(`/swim-meet/${data[id].id}/events`, { state: data[id] });
+    navigate(`/swim-meet/${data[id].id}/events`, {
+      state: { meetData: data[id] },
+    });
   };
 
   const handleEditClick = () => {


### PR DESCRIPTION
This PR address issue #133 which is part of #130.

### Implementation

1.  New components

- No new components were added.

2. Updates to Existing Components

- frontend/src/GenerateHeats/GenerateHeats.jsx
  - Props Added:
    - `setGenerateHeatTrigger`: This prop is used in `MeetEventDetails` to trigger a re-fetch of event data when heats are successfully generated for an event.
    - `switchView`: This function, passed from `MeetEventDetails`, resets state variables related to toggling between eventDetails and GenerateHeats views.
  - `handleGenerateHeats` Function: 
    - Updated to take `selectedAthletes` data and make a backend call to generate heats.
    - Displays an `alertBo`x with the result of the API call.
    - If successful, activates` setGenerateHeatTrigger` and calls `switchView`.

-  frontend/src/Event/MeetEventDisplay.jsx
   - Updated all "Generate Heats" button labels to "Create Heats".
   -  Added a `generateHeatTrigger` state to track when heats are generated for an event.
   - Created `handleSwitchGenerateToDetails` function to ensure that `eventDetails` renders for an event immediately after heats are generated.
   - Temporarily commented out the `Delete` action as it is currently not being worked on.


-  frontend/src/Event/EventDetails.jsx
   - Updated the "Generate Heats" button label to "Create Heats".
   - Styled the alert box to be larger when no heats are present for an event.