### PR TITLE
BE/FE - Download Heat Details as a xlsx file

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -15,6 +15,7 @@ from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
 from api.views.HeatView import HeatBatchView, HeatDetailView
 from api.views.LaneView import LaneBatchView, LaneDetailView
+from api.views.download.DownloadHeats import DownloadHeats
 
 from rest_framework.routers import SimpleRouter
 
@@ -42,6 +43,9 @@ urlpatterns = [
     path('event_heat/<int:event_id>/<int:heat_num>/', HeatDetailView.as_view(), name='heat-detail'),
     path('event_lane/<int:event_id>/', LaneBatchView.as_view(), name='lanes-event'),
     path('event_lane/<int:event_id>/<int:lane_num>/', LaneDetailView.as_view(), name='lane-detail'),
+    path('download-heats/<int:event_id>/<int:heat_num>/<str:res_type>',DownloadHeats.as_view(),name='downloadHeats_view')
+
 ]
+
 
 urlpatterns += router.urls

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -15,7 +15,7 @@ from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
 from api.views.HeatView import HeatBatchView, HeatDetailView
 from api.views.LaneView import LaneBatchView, LaneDetailView
-from api.views.download.DownloadHeats import DownloadHeats
+from api.views.download.DownloadHeats import DownloadAllHeatsByEvent
 
 from rest_framework.routers import SimpleRouter
 
@@ -49,9 +49,7 @@ urlpatterns = [
     path('event_lane/<int:event_id>/<int:lane_num>/',
          LaneDetailView.as_view(), name='lane-detail'),
     path('download-heats-details/<int:event_id>/',
-         DownloadHeats.as_view(), name='download-heats-details')
-
+         DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
 ]
-
 
 urlpatterns += router.urls

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     path('event_heat/<int:event_id>/<int:heat_num>/', HeatDetailView.as_view(), name='heat-detail'),
     path('event_lane/<int:event_id>/', LaneBatchView.as_view(), name='lanes-event'),
     path('event_lane/<int:event_id>/<int:lane_num>/', LaneDetailView.as_view(), name='lane-detail'),
-    path('download-heats/<int:event_id>/<int:heat_num>/<str:res_type>',DownloadHeats.as_view(),name='downloadHeats_view')
+    path('download-heats/<int:event_id>/<str:res_type>',DownloadHeats.as_view(),name='downloadHeats_view')
 
 ]
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -30,20 +30,26 @@ router.register(r'athlete', AthleteViewSet, basename='athlete')
 router.register(r'timerecord', TimeRecordViewSet, basename='timerecord')
 
 
-
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view()),
     path("login/refresh/", CustomTokenRefreshView.as_view()),
     path('logout/', LogoutView.as_view()),
     path('auth/', include('djoser.urls')),
-    path('meet_schools/<int:meet_id>/', MeetSchoolView.as_view(), name='meet-schools'),
+    path('meet_schools/<int:meet_id>/',
+         MeetSchoolView.as_view(), name='meet-schools'),
     path('meet_event/<int:meet_id>/', MeetEventView.as_view(), name='events-meet'),
-    path('seed_times/<int:event_id>/', AthleteSeedTimeView.as_view(), name='seed-times'),
-    path('event_heat/<int:event_id>/', HeatBatchView.as_view(), name='heats-event'),
-    path('event_heat/<int:event_id>/<int:heat_num>/', HeatDetailView.as_view(), name='heat-detail'),
-    path('event_lane/<int:event_id>/', LaneBatchView.as_view(), name='lanes-event'),
-    path('event_lane/<int:event_id>/<int:lane_num>/', LaneDetailView.as_view(), name='lane-detail'),
-    path('download-heats/<int:event_id>/<str:res_type>',DownloadHeats.as_view(),name='downloadHeats_view')
+    path('seed_times/<int:event_id>/',
+         AthleteSeedTimeView.as_view(), name='seed-times'),
+    path('event_heat/<int:event_id>/',
+         HeatBatchView.as_view(), name='heats-event'),
+    path('event_heat/<int:event_id>/<int:heat_num>/',
+         HeatDetailView.as_view(), name='heat-detail'),
+    path('event_lane/<int:event_id>/',
+         LaneBatchView.as_view(), name='lanes-event'),
+    path('event_lane/<int:event_id>/<int:lane_num>/',
+         LaneDetailView.as_view(), name='lane-detail'),
+    path('download-heats/<int:event_id>/',
+         DownloadHeats.as_view(), name='downloadHeats_view')
 
 ]
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -48,8 +48,8 @@ urlpatterns = [
          LaneBatchView.as_view(), name='lanes-event'),
     path('event_lane/<int:event_id>/<int:lane_num>/',
          LaneDetailView.as_view(), name='lane-detail'),
-    path('download-heats/<int:event_id>/',
-         DownloadHeats.as_view(), name='downloadHeats_view')
+    path('download-heats-details/<int:event_id>/',
+         DownloadHeats.as_view(), name='download-heats-details')
 
 ]
 

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -1,15 +1,11 @@
 from io import BytesIO
-import pandas as pd
 from api.models import Heat, MeetEvent
-from django.http import FileResponse, HttpResponse
-from docx import Document
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from django.http import HttpResponse
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 from openpyxl.styles import Alignment
-
 from rest_framework.views import APIView
-from api.serializers.HeatDisplaySerializer import HeatSerializer, LaneSerializer
 from datetime import timedelta
 
 

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -9,17 +9,16 @@ from openpyxl.utils import get_column_letter
 from openpyxl.styles import Alignment
 
 from rest_framework.views import APIView
-from api.serializers.HeatDisplaySerializer import HeatSerializer,LaneSerializer
-
+from api.serializers.HeatDisplaySerializer import HeatSerializer, LaneSerializer
 
 
 class DownloadHeats(APIView):
 
-    def generate_excel_from_lanes_data(self, event_name, heats_data, lanes_data):
+    def generate_excel_from_lanes_data(self, swim_meet_name, event_name, heats_data, lanes_data):
         # Create an in-memory workbook
         workbook = Workbook()
         heat_worksheet = workbook.active
-        heat_worksheet.title = "Heats Data"
+        heat_worksheet.title = "By Heats"
 
         # Headers for the heats table
         headers = ["Lane", "Athlete", "Seed Time", "Heat Time"]
@@ -28,13 +27,14 @@ class DownloadHeats(APIView):
 
         title_cell = heat_worksheet.cell(row=current_row, column=1)
         title_cell.value = event_name
-        heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+        heat_worksheet.merge_cells(
+            start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
         title_cell = heat_worksheet.cell(row=current_row, column=1)
         title_cell.style = 'Title'
-        title_cell.alignment = Alignment(horizontal='center', vertical='center')
-       
+        title_cell.alignment = Alignment(
+            horizontal='center', vertical='center')
+
         current_row += 2
-        
 
         for heat in heats_data:
             heat_name = heat.get("heat_name")
@@ -43,48 +43,47 @@ class DownloadHeats(APIView):
             # Set the title for each heat in the first cell of the row
             title_cell = heat_worksheet.cell(row=current_row, column=1)
             title_cell.value = heat_name
-            heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+            heat_worksheet.merge_cells(
+                start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
             title_cell.style = 'Title'
-            
+
             current_row += 1
-            
+
             # Set Headers
             for col_num, header in enumerate(headers, start=1):
                 cell = heat_worksheet.cell(row=current_row, column=col_num)
                 cell.value = header
-                cell.style = 'Headline 1' 
+                cell.style = 'Headline 1'
 
             # Populate the table with lane data for the current heat
             for lane in lanes:
                 current_row += 1
-                heat_worksheet.cell(row=current_row, column=1, value=lane.get("lane_num"))
-                heat_worksheet.cell(row=current_row, column=2, value=lane.get("athlete_full_name"))
-                heat_worksheet.cell(row=current_row, column=3, value=lane.get("seed_time"))
-                heat_worksheet.cell(row=current_row, column=4, value=lane.get("heat_time"))
+                heat_worksheet.cell(row=current_row, column=1,
+                                    value=lane.get("lane_num"))
+                heat_worksheet.cell(row=current_row, column=2,
+                                    value=lane.get("athlete_full_name"))
+                heat_worksheet.cell(row=current_row, column=3,
+                                    value=lane.get("seed_time"))
+                heat_worksheet.cell(row=current_row, column=4,
+                                    value=lane.get("heat_time"))
 
             current_row += 2
 
        # ========================= Lanes Data Worksheet =========================
-        lanes_worksheet = workbook.create_sheet(title="Lanes Data")
+        lanes_worksheet = workbook.create_sheet(title="By Lanes")
 
-        # Headers for the lanes data 
-        lanes_headers = ["Heat", "Athlete", "Seed Time", "Heat Time"]
+        # Headers for the lanes data
+        lanes_headers = ["Heat", "Athlete", "Heat Time"]
         current_row = 1
 
-        title_cell = heat_worksheet.cell(row=current_row, column=1)
-        title_cell.value = event_name
-        heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
-        title_cell = heat_worksheet.cell(row=current_row, column=1)
-        title_cell.style = 'Title'
-        title_cell.alignment = Alignment(horizontal='center', vertical='center')
-        
-        current_row += 2
-        
-        # Add a title for Lane Number
-        lanes_worksheet.cell(row=current_row, column=1, value="Lane Number")
-        lanes_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
         title_cell = lanes_worksheet.cell(row=current_row, column=1)
-        title_cell.alignment = Alignment(horizontal='center', vertical='center')
+        title_cell.value = event_name
+        lanes_worksheet.merge_cells(
+            start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+        title_cell = lanes_worksheet.cell(row=current_row, column=1)
+        title_cell.style = 'Title'
+        title_cell.alignment = Alignment(
+            horizontal='center', vertical='center')
 
         current_row += 2
 
@@ -93,28 +92,32 @@ class DownloadHeats(APIView):
             heats = lane.get("heats", [])
 
             # Set the title for each heat in the first cell of the row
-            title_cell = heat_worksheet.cell(row=current_row, column=1)
+            title_cell = lanes_worksheet.cell(row=current_row, column=1)
             title_cell.value = lane_name
-            heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
+            lanes_worksheet.merge_cells(
+                start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
             title_cell.style = 'Title'
-            
+
             # Move to the next row for headers
             current_row += 1
 
             # Add headers
-            for col_num, header in enumerate(headers, start=1):
-                cell = heat_worksheet.cell(row=current_row, column=col_num)
+            for col_num, header in enumerate(lanes_headers, start=1):
+                cell = lanes_worksheet.cell(row=current_row, column=col_num)
                 cell.value = header
-                cell.style = 'Headline 1'  
+                cell.style = 'Headline 1'
 
             # Populate the table with lane data for the current heat
             for heat in heats:
                 current_row += 1
-                heat_worksheet.cell(row=current_row, column=1, value=lane.get("num_heat"))
-                heat_worksheet.cell(row=current_row, column=2, value=lane.get("athlete_full_name"))
-                heat_worksheet.cell(row=current_row, column=3, value=lane.get("heat_time"))
+                lanes_worksheet.cell(row=current_row, column=1,
+                                     value=heat.get("num_heat"))
+                lanes_worksheet.cell(row=current_row, column=2,
+                                     value=heat.get("athlete_full_name"))
+                lanes_worksheet.cell(row=current_row, column=3,
+                                     value=heat.get("heat_time"))
 
-            current_row += 1
+            current_row += 2
 
         # Adjust column widths for readability in both worksheets
         for worksheet in [heat_worksheet, lanes_worksheet]:
@@ -132,84 +135,72 @@ class DownloadHeats(APIView):
             file_buffer,
             content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         )
-        response["Content-Disposition"] = 'attachment; filename="heats_data.xlsx"'
+        filename = swim_meet_name + "-" + event_name + ".xlsx"
+        response["Content-Disposition"] = 'attachment; filename=' + filename
         return response
-
-    
 
     @extend_schema(
         summary='Send Binary response',
-        parameters=[
-            OpenApiParameter(name='res_type',type=str,enum=['text','excel','docs'],required=True,location=OpenApiParameter.PATH),
-            OpenApiParameter(name='event_id',type=int,required=True,location=OpenApiParameter.QUERY),
-            OpenApiParameter(name='heat_num',type=int,required=True,location=OpenApiParameter.QUERY)
-        ],
         responses={
             200: OpenApiResponse(description='Binary Response'),
             404: OpenApiResponse(description='Resource not found')
         }
     )
-    def post(self,request,event_id, res_type): 
-        #Get event instance
+    def post(self, request, event_id):
+        # Get event instance
         event_instance = MeetEvent.objects.get(id=event_id)
         event_name = event_instance.name
 
-        #Get number of lanes on the event
+        # Get number of lanes on the event
         swim_meet_instance = event_instance.swim_meet
         num_lanes = swim_meet_instance.site.num_lanes
-        
-        max_num_heat = event_instance.total_num_heats 
+
+        swim_meet_name = swim_meet_instance.name
+
+        max_num_heat = event_instance.total_num_heats
 
         if max_num_heat:
-            heats_data = []
-            for heat_num in range (1,max_num_heat+1):
-                # Retrieve all heats for the given event_id and heat_num
-                heats = Heat.objects.filter(event_id=event_id, num_heat=heat_num)
+            by_heats_data = []
+            for heat_num in range(1, max_num_heat+1):
                 lanes_data = []
                 for lane_num in range(1, num_lanes + 1):
-                    lane_data = heats.filter(lane_num=lane_num).first()
-                    if lane_data is not None:
-                        lanes_data.append(lane_data)
-                    else:
-                        lanes_data.append({
-                            "id": None,
+                    lane = Heat.objects.filter(
+                        event_id=event_id, num_heat=heat_num, lane_num=lane_num).first()
+
+                    lanes_data.append(
+                        {
                             "lane_num": lane_num,
-                            "athlete": None,
-                            "seed_time": None,
-                            "heat_time": None
-                    })
-                serializer = HeatSerializer(lanes_data, many=True)
-                heats_data.append({
-                "id": heat_num,
-                "heat_name": f"Heat {heat_num}",
-                "lanes": serializer.data
-            })
-                
-            lanes_data = []
-            for lane_num in range (1,num_lanes+1):
-                # Retrieve all heats for the given event_id and lane_num
-                heats = Heat.objects.filter(event_id=event_id, lane_num=lane_num)
+                            "athlete_full_name": lane.athlete.full_name if lane and lane.athlete else None,
+                            "seed_time": lane.seed_time if lane else None,
+                            "heat_time": lane.heat_time if lane else None,
+                        }
+                    )
+
+                by_heats_data.append({
+                    "id": heat_num,
+                    "heat_name": f"Heat {heat_num}",
+                    "lanes": lanes_data
+                })
+            print(by_heats_data)
+            by_lanes_data = []
+
+            for lane_num in range(1, num_lanes+1):
                 heats_data = []
-                for heat in range(1, max_num_heat + 1):
-                    heat_data = heats.filter(num_heat=heat).first()
-                    if heat_data is not None:
-                        heats_data.append(heat_data)
-                    else:
-                        heats_data.append({
-                            "id": None,
-                            "num_heat": heat,
-                            "athlete": None,
-                            "seed_time": None
-                    })
-                serializer = LaneSerializer(heats_data, many=True)
-                lanes_data.append({
-                "id": lane_num,
-                "lane_name": f"Lane {lane_num}",
-                "heats": serializer.data
-            })
-            
-        print(heats_data)       
+                for heat_num in range(1, max_num_heat + 1):
+                    heat = Heat.objects.filter(
+                        event_id=event_id, lane_num=lane_num, num_heat=heat_num).first()
+                    heats_data.append(
+                        {
+                            "num_heat": heat_num,
+                            "athlete_full_name": heat.athlete.full_name if heat and heat.athlete else None,
+                            "seed_time": heat.seed_time if heat else None,
+                        }
+                    )
+                by_lanes_data.append({
+                    "id": lane_num,
+                    "lane_name": f"Lane {lane_num}",
+                    "heats": heats_data
+                })
 
-        if res_type == 'excel':
-           return self.generate_excel_from_lanes_data(event_name, heats_data, lanes_data)
-
+        print(by_lanes_data)
+        return self.generate_excel_from_lanes_data(swim_meet_name, event_name, by_heats_data, by_lanes_data)

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -9,136 +9,179 @@ from rest_framework.views import APIView
 from datetime import timedelta
 
 
-@extend_schema(tags=['Download'])
-class DownloadHeats(APIView):
+def create_excel_file_for_heats_details(swim_meet_details, event_data):
 
-    def generate_excel_for_event_heats(self, swim_meet_name, event_name, heats_data, lanes_data):
-        # Create an in-memory workbook
-        workbook = Workbook()
-        heat_worksheet = workbook.active
-        heat_worksheet.title = "By Heats"
+    workbook = Workbook()
+    # ========================= By Heats Worksheet =========================
+    heats_worksheet = workbook.active
+    heats_worksheet.title = "By Heats"
+    heats_headers = ["Lane", "Athlete", "Seed Time", "Heat Time"]
+    current_row = 1
 
-        # Headers for the heats table
-        heats_headers = ["Lane", "Athlete", "Seed Time", "Heat Time"]
+    heats_worksheet.merge_cells(
+        start_row=1, start_column=1, end_row=1, end_column=len(heats_headers))
+    swim_meet_cell = heats_worksheet.cell(row=1, column=1)
+    swim_meet_cell.value = f"{swim_meet_details['name']}\n{swim_meet_details['date']}\n{swim_meet_details['location']}"
+    swim_meet_cell.style = 'Title'
+    swim_meet_cell.alignment = Alignment(
+        horizontal="center", vertical="center", wrap_text=True)
 
-        current_row = 1
-
-        title_cell = heat_worksheet.cell(row=current_row, column=1)
-        title_cell.value = event_name
-        heat_worksheet.merge_cells(
+    current_row += 3
+    for event in event_data:
+        event_cell = heats_worksheet.cell(row=current_row, column=1)
+        event_cell.value = event["event_name"]
+        heats_worksheet.merge_cells(
             start_row=current_row, start_column=1, end_row=current_row, end_column=len(heats_headers))
-        title_cell = heat_worksheet.cell(row=current_row, column=1)
-        title_cell.style = 'Title'
-        title_cell.alignment = Alignment(
-            horizontal='center', vertical='center')
-
+        event_cell.style = 'Headline 1'
         current_row += 2
 
-        for heat in heats_data:
-            heat_name = heat.get("heat_name")
-            lanes = heat.get("lanes", [])
+        if event["heats"]:
+            for heat in event["heats"]:
+                heat_name = heat["heat_name"]
+                lanes = heat["lanes"]
+                heat_cell = heats_worksheet.cell(row=current_row, column=1)
+                heat_cell.value = heat_name
+                heats_worksheet.merge_cells(
+                    start_row=current_row, start_column=1, end_row=current_row, end_column=len(heats_headers))
+                heat_cell.style = 'Headline 2'
 
-            # Set the title for each heat in the first cell of the row
-            title_cell = heat_worksheet.cell(row=current_row, column=1)
-            title_cell.value = heat_name
-            heat_worksheet.merge_cells(
-                start_row=current_row, start_column=1, end_row=current_row, end_column=len(heats_headers))
-            title_cell.style = 'Title'
-
-            current_row += 1
-
-            # Set Headers
-            for col_num, header in enumerate(heats_headers, start=1):
-                cell = heat_worksheet.cell(row=current_row, column=col_num)
-                cell.value = header
-                cell.style = 'Headline 1'
-
-            # Populate the table with lane data for the current heat
-            for lane in lanes:
                 current_row += 1
-                heat_worksheet.cell(row=current_row, column=1,
-                                    value=lane.get("lane_num"))
-                heat_worksheet.cell(row=current_row, column=2,
-                                    value=lane.get("athlete_full_name"))
-                heat_worksheet.cell(row=current_row, column=3,
-                                    value=lane.get("seed_time"))
-                heat_worksheet.cell(row=current_row, column=4,
-                                    value=lane.get("heat_time"))
 
+                # Headers
+                for col_num, header in enumerate(heats_headers, start=1):
+                    header_cell = heats_worksheet.cell(
+                        row=current_row, column=col_num)
+                    header_cell.value = header
+                    header_cell.style = 'Headline 3'
+
+                current_row += 1
+
+                # Data
+                for lane in lanes:
+                    heats_worksheet.cell(
+                        row=current_row, column=1, value=lane["lane_num"])
+                    heats_worksheet.cell(
+                        row=current_row, column=2, value=lane["athlete_full_name"])
+                    heats_worksheet.cell(
+                        row=current_row, column=3, value=lane["seed_time"])
+                    heats_worksheet.cell(
+                        row=current_row, column=4, value=lane["heat_time"])
+                    current_row += 1
+                current_row += 2
+        else:
+
+            heats_worksheet.cell(row=current_row, column=1,
+                                 value="This event has no heats yet.")
             current_row += 2
 
-        # Adjust column widths
-        for col_num, header in enumerate(heats_headers, 1):
-            col_letter = get_column_letter(col_num)
-            heat_worksheet.column_dimensions[col_letter].width = 15
+    for col_num in range(1, len(heats_headers) + 1):
+        col_letter = get_column_letter(col_num)
+        heats_worksheet.column_dimensions[col_letter].width = 15
 
-       # ========================= Lanes Data Worksheet =========================
-        lanes_worksheet = workbook.create_sheet(title="By Lanes")
+    # ========================= By Lanes Worksheet =========================
+    lanes_worksheet = workbook.create_sheet(title="By Lanes")
+    lanes_headers = ["Heat ", "Heat Time"]
+    current_row = 1
 
-        # Headers for the lanes data
-        lanes_headers = ["Heat", "Athlete", "Heat Time"]
-        current_row = 1
+    lanes_worksheet.merge_cells(
+        start_row=1, start_column=1, end_row=1, end_column=len(heats_headers))
+    swim_meet_cell = lanes_worksheet.cell(row=1, column=1)
+    swim_meet_cell.value = f"{swim_meet_details['name']}\n{swim_meet_details['date']}\n{swim_meet_details['location']}"
+    swim_meet_cell.style = 'Title'
+    swim_meet_cell.alignment = Alignment(
+        horizontal="center", vertical="center", wrap_text=True)
 
-        title_cell = lanes_worksheet.cell(row=current_row, column=1)
-        title_cell.value = event_name
+    current_row += 3
+
+    for event in event_data:
+        event_cell = lanes_worksheet.cell(row=current_row, column=1)
+        event_cell.value = event["event_name"]
         lanes_worksheet.merge_cells(
             start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
-        title_cell = lanes_worksheet.cell(row=current_row, column=1)
-        title_cell.style = 'Title'
-        title_cell.alignment = Alignment(
+        event_cell.alignment = Alignment(
             horizontal='center', vertical='center')
+        event_cell.style = 'Headline 1'
 
         current_row += 2
 
-        for lane in lanes_data:
-            lane_name = lane.get("lane_name")
-            heats = lane.get("heats", [])
+        if event["heats"]:
+            for lane in event["lanes"]:
+                lane_name = lane["lane_name"]
+                heats = lane["heats"]
 
-            # Set the title for each heat in the first cell of the row
-            title_cell = lanes_worksheet.cell(row=current_row, column=1)
-            title_cell.value = lane_name
-            lanes_worksheet.merge_cells(
-                start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
-            title_cell.style = 'Title'
-
-            current_row += 1
-
-            # Set headers
-            for col_num, header in enumerate(lanes_headers, start=1):
-                cell = lanes_worksheet.cell(row=current_row, column=col_num)
-                cell.value = header
-                cell.style = 'Headline 1'
-
-            # Populate the table with heat data for the current lane
-            for heat in heats:
+                lane_cell = lanes_worksheet.cell(row=current_row, column=1)
+                lane_cell.value = lane_name
+                lanes_worksheet.merge_cells(
+                    start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
                 current_row += 1
-                lanes_worksheet.cell(row=current_row, column=1,
-                                     value=heat.get("num_heat"))
-                lanes_worksheet.cell(row=current_row, column=2,
-                                     value=heat.get("athlete_full_name"))
-                lanes_worksheet.cell(row=current_row, column=3,
-                                     value=heat.get("heat_time"))
+                lane_cell.style = 'Headline 2'
 
+                # Headers
+                header_cell = lanes_worksheet.cell(
+                    row=current_row, column=2)
+                header_cell.value = lanes_headers[1]
+                header_cell.style = 'Headline 3'
+
+                # Data
+                for heat in heats:
+                    header_cell = lanes_worksheet.cell(
+                        row=current_row, column=1)
+                    header_cell.value = lanes_headers[0] + \
+                        str(heat["num_heat"])
+                    header_cell.style = 'Headline 3'
+                    current_row += 1
+
+                    lanes_worksheet.cell(
+                        row=current_row, column=1, value=heat["athlete_full_name"])
+                    lanes_worksheet.cell(
+                        row=current_row, column=2, value=heat["heat_time"])
+                    current_row += 2
+
+                current_row += 1
+
+        else:
+
+            lanes_worksheet.cell(row=current_row, column=1,
+                                 value="This event has no heats yet.")
             current_row += 2
 
-        # Adjust column widths for readability in both worksheets
-        for col_num in range(1, len(lanes_headers) + 1):
-            col_letter = get_column_letter(col_num)
-            lanes_worksheet.column_dimensions[col_letter].width = 15
+    for col_num in range(1, len(lanes_headers) + 1):
+        col_letter = get_column_letter(col_num)
+        lanes_worksheet.column_dimensions[col_letter].width = 15
 
-        # Save the workbook to an in-memory file
-        file_buffer = BytesIO()
-        workbook.save(file_buffer)
-        file_buffer.seek(0)
+    # Save workbook to an in-memory file
+    file_buffer = BytesIO()
+    workbook.save(file_buffer)
+    file_buffer.seek(0)
 
-        # Create an HTTP response with the Excel file for download
-        response = HttpResponse(
-            file_buffer,
-            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
-        filename = swim_meet_name + "-" + event_name + ".xlsx"
-        response["Content-Disposition"] = 'attachment; filename=' + filename
-        return response
+    return file_buffer
+
+
+def format_time(time):
+    if not time:
+        return None
+    if time == timedelta(days=200):
+        return "NT"
+    elif time == timedelta(days=300):
+        return "NS"
+    elif time == timedelta(days=400):
+        return "DQ"
+
+    time_parts = str(time).split(":")
+    seconds_and_millis = f"{float(time_parts[2]):.2f}"
+
+    if time_parts[0] != "0":
+        return f"{time_parts[0]}:{time_parts[1]}:{seconds_and_millis}"
+
+    if time_parts[1] != "00":
+        minutes = int(time_parts[1])
+        return f"{minutes}:{seconds_and_millis}"
+
+    return seconds_and_millis
+
+
+@extend_schema(tags=['Download'])
+class DownloadAllHeatsByEvent(APIView):
 
     @extend_schema(
         summary='Send Binary response',
@@ -148,60 +191,80 @@ class DownloadHeats(APIView):
         }
     )
     def post(self, request, event_id):
+
+        event_data = []
+
         # Get event instance
         event_instance = MeetEvent.objects.get(id=event_id)
         event_name = event_instance.name
 
         # Get number of lanes on the event
         swim_meet_instance = event_instance.swim_meet
-        num_lanes = swim_meet_instance.site.num_lanes
 
-        swim_meet_name = swim_meet_instance.name
+        swim_meet_details = {
+            'name': swim_meet_instance.name,
+            'date': swim_meet_instance.date.strftime('%m-%d-%Y'),
+            'location': swim_meet_instance.site.name
+        }
+
+        num_lanes = swim_meet_instance.site.num_lanes
 
         max_num_heat = event_instance.total_num_heats
 
-        if max_num_heat:
-            by_heats_data = []
-            for heat_num in range(1, max_num_heat+1):
-                lanes_data = []
-                for lane_num in range(1, num_lanes + 1):
-                    lane = Heat.objects.filter(
-                        event_id=event_id, num_heat=heat_num, lane_num=lane_num).first()
-                    seed_time = lane.seed_time if lane else None
-                    if seed_time and seed_time == timedelta(days=200):
-                        seed_time = "NT"
-                    lanes_data.append(
-                        {
-                            "lane_num": lane_num,
-                            "athlete_full_name": lane.athlete.full_name if lane and lane.athlete else None,
-                            "seed_time": seed_time,
-                            "heat_time": lane.heat_time if lane else None,
-                        }
-                    )
+        by_heats_data = []
+        for heat_num in range(1, max_num_heat+1):
+            lanes_data = []
+            for lane_num in range(1, num_lanes + 1):
+                lane = Heat.objects.filter(
+                    event_id=event_id, num_heat=heat_num, lane_num=lane_num).first()
+                seed_time = format_time(lane.seed_time) if lane else ""
+                heat_time = format_time(lane.heat_time) if lane else ""
+                lanes_data.append(
+                    {
+                        "lane_num": lane_num,
+                        "athlete_full_name": lane.athlete.full_name if lane and lane.athlete else None,
+                        "seed_time": seed_time,
+                        "heat_time": heat_time,
+                    }
+                )
 
-                by_heats_data.append({
-                    "id": heat_num,
-                    "heat_name": f"Heat {heat_num}",
-                    "lanes": lanes_data
-                })
-            by_lanes_data = []
+            by_heats_data.append({
+                "id": heat_num,
+                "heat_name": f"Heat {heat_num} of {max_num_heat}",
+                "lanes": lanes_data
+            })
+        by_lanes_data = []
 
-            for lane_num in range(1, num_lanes+1):
-                heats_data = []
-                for heat_num in range(1, max_num_heat + 1):
-                    heat = Heat.objects.filter(
-                        event_id=event_id, lane_num=lane_num, num_heat=heat_num).first()
-                    heats_data.append(
-                        {
-                            "num_heat": heat_num,
-                            "athlete_full_name": heat.athlete.full_name if heat and heat.athlete else None,
-                            "heat_time": heat.heat_time if heat else None,
-                        }
-                    )
-                by_lanes_data.append({
-                    "id": lane_num,
-                    "lane_name": f"Lane {lane_num}",
-                    "heats": heats_data
-                })
+        for lane_num in range(1, num_lanes+1):
+            heats_data = []
+            for heat_num in range(1, max_num_heat + 1):
+                heat = Heat.objects.filter(
+                    event_id=event_id, lane_num=lane_num, num_heat=heat_num).first()
+                heat_time = format_time(heat.heat_time) if heat else ""
+                heats_data.append(
+                    {
+                        "num_heat": heat_num,
+                        "athlete_full_name": heat.athlete.full_name if heat and heat.athlete else None,
+                        "heat_time": heat_time,
+                    }
+                )
 
-        return self.generate_excel_for_event_heats(swim_meet_name, event_name, by_heats_data, by_lanes_data)
+            by_lanes_data.append({
+                "id": lane_num,
+                "lane_name": f"Lane {lane_num} of {num_lanes}",
+                "heats": heats_data
+            })
+        event_data.append(
+            {"event_name": event_name, "heats": by_heats_data, "lanes": by_lanes_data})
+
+        file = create_excel_file_for_heats_details(
+            swim_meet_details, event_data)
+        file_name = swim_meet_instance.name + "-" + event_name + ".xlsx"
+
+        # Create HTTP response
+        response = HttpResponse(
+            file,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        response["Content-Disposition"] = 'attachment; filename=' + file_name
+        return response

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -1,0 +1,120 @@
+from io import BytesIO
+import pandas as pd
+from api.models import Heat, MeetEvent
+from django.http import FileResponse, HttpResponse
+from docx import Document
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+from rest_framework.views import APIView
+
+
+class DownloadHeats(APIView):
+
+
+    def generate_excel_from_lanes_data(self, lanes_data):
+        # Create an in-memory workbook and worksheet
+        workbook = Workbook()
+        worksheet = workbook.active
+        worksheet.title = "Lanes Data"
+
+        # Define headers for the fields in lanes_data
+        headers = ["Lane Number", "Athlete Name", "Seed Time", "Result Time", "Event"]
+        for col_num, header in enumerate(headers, 1):
+            cell = worksheet.cell(row=1, column=col_num)
+            cell.value = header
+            cell.style = 'Headline 1'  # Optional: adds style to headers
+
+        # Populate the worksheet with lanes_data
+        for row_num, lane in enumerate(lanes_data, 2):  # Start at row 2 to leave space for headers
+            worksheet.cell(row=row_num, column=1, value=lane.get("lane_number"))
+            worksheet.cell(row=row_num, column=2, value=lane.get("athlete_name"))
+            worksheet.cell(row=row_num, column=3, value=lane.get("seed_time"))
+            worksheet.cell(row=row_num, column=4, value=lane.get("result_time"))
+            worksheet.cell(row=row_num, column=5, value=lane.get("event_name"))
+
+        # Adjust column widths
+        for col_num, header in enumerate(headers, 1):
+            col_letter = get_column_letter(col_num)
+            worksheet.column_dimensions[col_letter].width = 15  # Adjust as needed
+
+        # Save the workbook to an in-memory file
+        file_buffer = BytesIO()
+        workbook.save(file_buffer)
+        file_buffer.seek(0)  # Move to the start of the file
+
+        # Create an HTTP response with the Excel file for download
+        response = HttpResponse(
+            file_buffer,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        response["Content-Disposition"] = 'attachment; filename="lanes_data.xlsx"'
+        return response
+
+
+    def get_excel(self,queryset):
+        file_name = 'Heats.xlsx'
+        byte_buffer = BytesIO()
+        df = pd.DataFrame.from_dict(queryset.values())
+        writer = pd.ExcelWriter(byte_buffer,engine='xlsxwriter')
+        df.to_excel(writer,sheet_name='Heats',index=False)
+        df2 = pd.DataFrame.from_dict(queryset.filter(lane_num=1).values())  
+        df2.to_excel(writer,sheet_name='Lanes',index=False)
+        writer.close()
+        return byte_buffer,file_name
+
+    
+
+    @extend_schema(
+        summary='Send Binary response',
+        parameters=[
+            OpenApiParameter(name='res_type',type=str,enum=['text','excel','docs'],required=True,location=OpenApiParameter.PATH),
+            OpenApiParameter(name='event_id',type=int,required=True,location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='heat_num',type=int,required=True,location=OpenApiParameter.QUERY)
+        ],
+        responses={
+            200: OpenApiResponse(description='Binary Response'),
+            404: OpenApiResponse(description='Resource not found')
+        }
+    )
+    def post(self,request,event_id, heat_num, res_type): 
+        #Get event instance
+        event_instance = MeetEvent.objects.get(id=event_id)
+          
+        #Get number of lanes on the event
+        swim_meet_instance = event_instance.swim_meet
+        num_lanes = swim_meet_instance.site.num_lanes
+         
+        #Get number of heats on the event
+        max_num_heat = event_instance.total_num_heats 
+        if max_num_heat:
+            if 1<= heat_num <= max_num_heat:
+                # Retrieve all heats for the given event_id and heat_num
+                heats = Heat.objects.filter(event_id=event_id, num_heat=heat_num)
+                lanes_data = []
+                for lane_num in range(1, num_lanes + 1):
+                    lane_data = heats.filter(lane_num=lane_num).first()
+                    if lane_data is not None:
+                        lanes_data.append({
+                            "lane_number": lane_data.lane_num,
+                            "athlete_name": lane_data.athlete.full_name if lane_data.athlete else None,
+                            "seed_time": lane_data.seed_time,
+                            "result_time": lane_data.heat_time,
+                            "event_name": event_instance.name
+                        })
+                    else:
+                        lanes_data.append({
+                            "id": None,
+                            "lane_num": lane_num,
+                            "athlete": None,
+                            "seed_time": None,
+                            "heat_time": None
+                    })
+
+
+        if res_type == 'excel':
+            #byte_buffer,file_name = self.get_excel(lanes_data)
+        #byte_buffer.seek(0)
+        #return FileResponse(byte_buffer,filename=file_name,as_attachment=True)
+            return self.generate_excel_from_lanes_data(lanes_data)
+

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -6,62 +6,134 @@ from docx import Document
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
+from openpyxl.styles import Alignment
+
 from rest_framework.views import APIView
+from api.serializers.HeatDisplaySerializer import HeatSerializer,LaneSerializer
+
 
 
 class DownloadHeats(APIView):
 
-
-    def generate_excel_from_lanes_data(self, lanes_data):
-        # Create an in-memory workbook and worksheet
+    def generate_excel_from_lanes_data(self, event_name, heats_data, lanes_data):
+        # Create an in-memory workbook
         workbook = Workbook()
-        worksheet = workbook.active
-        worksheet.title = "Lanes Data"
+        heat_worksheet = workbook.active
+        heat_worksheet.title = "Heats Data"
 
-        # Define headers for the fields in lanes_data
-        headers = ["Lane Number", "Athlete Name", "Seed Time", "Result Time", "Event"]
-        for col_num, header in enumerate(headers, 1):
-            cell = worksheet.cell(row=1, column=col_num)
-            cell.value = header
-            cell.style = 'Headline 1'  # Optional: adds style to headers
+        # Headers for the heats table
+        headers = ["Lane", "Athlete", "Seed Time", "Heat Time"]
 
-        # Populate the worksheet with lanes_data
-        for row_num, lane in enumerate(lanes_data, 2):  # Start at row 2 to leave space for headers
-            worksheet.cell(row=row_num, column=1, value=lane.get("lane_number"))
-            worksheet.cell(row=row_num, column=2, value=lane.get("athlete_name"))
-            worksheet.cell(row=row_num, column=3, value=lane.get("seed_time"))
-            worksheet.cell(row=row_num, column=4, value=lane.get("result_time"))
-            worksheet.cell(row=row_num, column=5, value=lane.get("event_name"))
+        current_row = 1
 
-        # Adjust column widths
-        for col_num, header in enumerate(headers, 1):
-            col_letter = get_column_letter(col_num)
-            worksheet.column_dimensions[col_letter].width = 15  # Adjust as needed
+        title_cell = heat_worksheet.cell(row=current_row, column=1)
+        title_cell.value = event_name
+        heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+        title_cell = heat_worksheet.cell(row=current_row, column=1)
+        title_cell.style = 'Title'
+        title_cell.alignment = Alignment(horizontal='center', vertical='center')
+       
+        current_row += 2
+        
+
+        for heat in heats_data:
+            heat_name = heat.get("heat_name")
+            lanes = heat.get("lanes", [])
+
+            # Set the title for each heat in the first cell of the row
+            title_cell = heat_worksheet.cell(row=current_row, column=1)
+            title_cell.value = heat_name
+            heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+            title_cell.style = 'Title'
+            
+            current_row += 1
+            
+            # Set Headers
+            for col_num, header in enumerate(headers, start=1):
+                cell = heat_worksheet.cell(row=current_row, column=col_num)
+                cell.value = header
+                cell.style = 'Headline 1' 
+
+            # Populate the table with lane data for the current heat
+            for lane in lanes:
+                current_row += 1
+                heat_worksheet.cell(row=current_row, column=1, value=lane.get("lane_num"))
+                heat_worksheet.cell(row=current_row, column=2, value=lane.get("athlete_full_name"))
+                heat_worksheet.cell(row=current_row, column=3, value=lane.get("seed_time"))
+                heat_worksheet.cell(row=current_row, column=4, value=lane.get("heat_time"))
+
+            current_row += 2
+
+       # ========================= Lanes Data Worksheet =========================
+        lanes_worksheet = workbook.create_sheet(title="Lanes Data")
+
+        # Headers for the lanes data 
+        lanes_headers = ["Heat", "Athlete", "Seed Time", "Heat Time"]
+        current_row = 1
+
+        title_cell = heat_worksheet.cell(row=current_row, column=1)
+        title_cell.value = event_name
+        heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(headers))
+        title_cell = heat_worksheet.cell(row=current_row, column=1)
+        title_cell.style = 'Title'
+        title_cell.alignment = Alignment(horizontal='center', vertical='center')
+        
+        current_row += 2
+        
+        # Add a title for Lane Number
+        lanes_worksheet.cell(row=current_row, column=1, value="Lane Number")
+        lanes_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
+        title_cell = lanes_worksheet.cell(row=current_row, column=1)
+        title_cell.alignment = Alignment(horizontal='center', vertical='center')
+
+        current_row += 2
+
+        for lane in lanes_data:
+            lane_name = heat.get("lane_name")
+            heats = lane.get("heats", [])
+
+            # Set the title for each heat in the first cell of the row
+            title_cell = heat_worksheet.cell(row=current_row, column=1)
+            title_cell.value = lane_name
+            heat_worksheet.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=len(lanes_headers))
+            title_cell.style = 'Title'
+            
+            # Move to the next row for headers
+            current_row += 1
+
+            # Add headers
+            for col_num, header in enumerate(headers, start=1):
+                cell = heat_worksheet.cell(row=current_row, column=col_num)
+                cell.value = header
+                cell.style = 'Headline 1'  
+
+            # Populate the table with lane data for the current heat
+            for heat in heats:
+                current_row += 1
+                heat_worksheet.cell(row=current_row, column=1, value=lane.get("num_heat"))
+                heat_worksheet.cell(row=current_row, column=2, value=lane.get("athlete_full_name"))
+                heat_worksheet.cell(row=current_row, column=3, value=lane.get("heat_time"))
+
+            current_row += 1
+
+        # Adjust column widths for readability in both worksheets
+        for worksheet in [heat_worksheet, lanes_worksheet]:
+            for col_num in range(1, len(headers) + 1):
+                col_letter = get_column_letter(col_num)
+                worksheet.column_dimensions[col_letter].width = 15
 
         # Save the workbook to an in-memory file
         file_buffer = BytesIO()
         workbook.save(file_buffer)
-        file_buffer.seek(0)  # Move to the start of the file
+        file_buffer.seek(0)
 
         # Create an HTTP response with the Excel file for download
         response = HttpResponse(
             file_buffer,
             content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         )
-        response["Content-Disposition"] = 'attachment; filename="lanes_data.xlsx"'
+        response["Content-Disposition"] = 'attachment; filename="heats_data.xlsx"'
         return response
-
-
-    def get_excel(self,queryset):
-        file_name = 'Heats.xlsx'
-        byte_buffer = BytesIO()
-        df = pd.DataFrame.from_dict(queryset.values())
-        writer = pd.ExcelWriter(byte_buffer,engine='xlsxwriter')
-        df.to_excel(writer,sheet_name='Heats',index=False)
-        df2 = pd.DataFrame.from_dict(queryset.filter(lane_num=1).values())  
-        df2.to_excel(writer,sheet_name='Lanes',index=False)
-        writer.close()
-        return byte_buffer,file_name
 
     
 
@@ -77,31 +149,27 @@ class DownloadHeats(APIView):
             404: OpenApiResponse(description='Resource not found')
         }
     )
-    def post(self,request,event_id, heat_num, res_type): 
+    def post(self,request,event_id, res_type): 
         #Get event instance
         event_instance = MeetEvent.objects.get(id=event_id)
-          
+        event_name = event_instance.name
+
         #Get number of lanes on the event
         swim_meet_instance = event_instance.swim_meet
         num_lanes = swim_meet_instance.site.num_lanes
-         
-        #Get number of heats on the event
+        
         max_num_heat = event_instance.total_num_heats 
+
         if max_num_heat:
-            if 1<= heat_num <= max_num_heat:
+            heats_data = []
+            for heat_num in range (1,max_num_heat+1):
                 # Retrieve all heats for the given event_id and heat_num
                 heats = Heat.objects.filter(event_id=event_id, num_heat=heat_num)
                 lanes_data = []
                 for lane_num in range(1, num_lanes + 1):
                     lane_data = heats.filter(lane_num=lane_num).first()
                     if lane_data is not None:
-                        lanes_data.append({
-                            "lane_number": lane_data.lane_num,
-                            "athlete_name": lane_data.athlete.full_name if lane_data.athlete else None,
-                            "seed_time": lane_data.seed_time,
-                            "result_time": lane_data.heat_time,
-                            "event_name": event_instance.name
-                        })
+                        lanes_data.append(lane_data)
                     else:
                         lanes_data.append({
                             "id": None,
@@ -110,11 +178,38 @@ class DownloadHeats(APIView):
                             "seed_time": None,
                             "heat_time": None
                     })
-
+                serializer = HeatSerializer(lanes_data, many=True)
+                heats_data.append({
+                "id": heat_num,
+                "heat_name": f"Heat {heat_num}",
+                "lanes": serializer.data
+            })
+                
+            lanes_data = []
+            for lane_num in range (1,num_lanes+1):
+                # Retrieve all heats for the given event_id and lane_num
+                heats = Heat.objects.filter(event_id=event_id, lane_num=lane_num)
+                heats_data = []
+                for heat in range(1, max_num_heat + 1):
+                    heat_data = heats.filter(num_heat=heat).first()
+                    if heat_data is not None:
+                        heats_data.append(heat_data)
+                    else:
+                        heats_data.append({
+                            "id": None,
+                            "num_heat": heat,
+                            "athlete": None,
+                            "seed_time": None
+                    })
+                serializer = LaneSerializer(heats_data, many=True)
+                lanes_data.append({
+                "id": lane_num,
+                "lane_name": f"Lane {lane_num}",
+                "heats": serializer.data
+            })
+            
+        print(heats_data)       
 
         if res_type == 'excel':
-            #byte_buffer,file_name = self.get_excel(lanes_data)
-        #byte_buffer.seek(0)
-        #return FileResponse(byte_buffer,filename=file_name,as_attachment=True)
-            return self.generate_excel_from_lanes_data(lanes_data)
+           return self.generate_excel_from_lanes_data(event_name, heats_data, lanes_data)
 

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -10,13 +10,13 @@ from openpyxl.styles import Alignment
 
 from rest_framework.views import APIView
 from api.serializers.HeatDisplaySerializer import HeatSerializer, LaneSerializer
-from datetime import timedelta
+sx from datetime import timedelta
 
 
 @extend_schema(tags=['Download'])
 class DownloadHeats(APIView):
 
-    def generate_excel_from_lanes_data(self, swim_meet_name, event_name, heats_data, lanes_data):
+    def generate_excel_for_event_heats(self, swim_meet_name, event_name, heats_data, lanes_data):
         # Create an in-memory workbook
         workbook = Workbook()
         heat_worksheet = workbook.active
@@ -208,4 +208,4 @@ class DownloadHeats(APIView):
                     "heats": heats_data
                 })
 
-        return self.generate_excel_from_lanes_data(swim_meet_name, event_name, by_heats_data, by_lanes_data)
+        return self.generate_excel_for_event_heats(swim_meet_name, event_name, by_heats_data, by_lanes_data)

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -10,7 +10,7 @@ from openpyxl.styles import Alignment
 
 from rest_framework.views import APIView
 from api.serializers.HeatDisplaySerializer import HeatSerializer, LaneSerializer
-sx from datetime import timedelta
+from datetime import timedelta
 
 
 @extend_schema(tags=['Download'])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ gunicorn==21.2.0
 psycopg2==2.9.9
 whitenoise==6.6.0
 djoser==2.2.2
+openpyxl==3.1.5

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -3,9 +3,12 @@ import { SmmApi } from "../SmmApi.jsx";
 import ItemPaginationBar from "../components/Common/ItemPaginationBar";
 import TabPanel from "../components/Common/TabPanel";
 import ExpandableTable from "../components/Common/ExpandableTable";
-import { ContentPaste as BackIcon } from "@mui/icons-material";
 import AlertBox from "../components/Common/AlertBox.jsx";
-import { Build as BuildIcon } from "@mui/icons-material";
+import {
+  ContentPaste as BackIcon,
+  Build as BuildIcon,
+  Download as DownloadIcon,
+} from "@mui/icons-material";
 import { Stack } from "@mui/material";
 import { formatSeedTime } from "../utils/helperFunctions.js";
 
@@ -16,6 +19,7 @@ const EventDetails = ({
   onPrevious,
   onNext,
   onGenerate,
+  onDownload,
   disablePrevious,
   disableNext,
 }) => {
@@ -60,6 +64,12 @@ const EventDetails = ({
       label: "Back to events",
       icon: <BackIcon />,
       onClick: onBack,
+    },
+    {
+      label: "Download Details",
+      icon: <DownloadIcon />,
+      onClick: onDownload,
+      disabled: numHeats === 0,
     },
   ];
 

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -12,6 +12,7 @@ import {
   EmojiEvents as RankingIcon,
   Add as AddIcon,
   Build as BuildIcon,
+  Download as DownloadIcon,
 } from "@mui/icons-material";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import { Stack, Box } from "@mui/material";
@@ -74,6 +75,20 @@ const MeetEventDisplay = () => {
   const handleRankingClick = (id) => {
     console.log("Ranking ...");
   };
+  const handleDownloadDetails = async (id) => {
+    setSelectedEventIndex(Number(id));
+    try {
+      await SmmApi.downloadHeatDetails(
+        meetData.name,
+        eventData[selectedEventIndex].name,
+        eventData[selectedEventIndex].id
+      );
+      console.log("Download initiated.");
+    } catch (error) {
+      console.error("Download failed:", error);
+      alert("There was an error downloading the file. Please try again.");
+    }
+  };
 
   const actions = [
     {
@@ -101,6 +116,13 @@ const MeetEventDisplay = () => {
       icon: <RankingIcon />,
       onClick: handleRankingClick,
       tip: "Go to ranking",
+    },
+    {
+      name: "Download Heats Details",
+      icon: <DownloadIcon />,
+      onClick: handleDownloadDetails,
+      tip: "Download Heats Details",
+      visible: (row) => row.original.total_num_heats > 0,
     },
   ];
 
@@ -201,6 +223,7 @@ const MeetEventDisplay = () => {
             onPrevious={handlePreviousEvent}
             onNext={handleNextEvent}
             onGenerate={handleGenerateButton}
+            onDownload={handleDownloadDetails}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
           />

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -76,12 +76,12 @@ const MeetEventDisplay = () => {
     console.log("Ranking ...");
   };
   const handleDownloadDetails = async (id) => {
-    setSelectedEventIndex(Number(id));
+    let currentEvent = selectedEventIndex ? selectedEventIndex : Number(id);
     try {
       await SmmApi.downloadHeatDetails(
         meetData.name,
-        eventData[selectedEventIndex].name,
-        eventData[selectedEventIndex].id
+        eventData[currentEvent].name,
+        eventData[currentEvent].id
       );
     } catch (error) {
       console.error("Download failed:", error);

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -83,7 +83,6 @@ const MeetEventDisplay = () => {
         eventData[selectedEventIndex].name,
         eventData[selectedEventIndex].id
       );
-      console.log("Download initiated.");
     } catch (error) {
       console.error("Download failed:", error);
       alert("There was an error downloading the file. Please try again.");

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -199,4 +199,34 @@ export class SmmApi {
       headers: getConfig(),
     });
   }
+
+  static async downloadHeatDetails(swimMeetName, eventName, eventId) {
+    try {
+      const response = await axios.post(
+        `${BASE_URL}/download-heats-details/${eventId}/`,
+        {},
+        {
+          headers: getConfig(),
+          responseType: "blob", // Important for file downloads
+        }
+      );
+
+      // Create a URL for the blob and trigger the download
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+
+      // Set the file name
+      link.setAttribute("download", `${swimMeetName}_${eventName}.xlsx`);
+
+      document.body.appendChild(link);
+      link.click();
+
+      // Cleanup
+      link.parentNode.removeChild(link);
+    } catch (error) {
+      console.error("Error downloading heats file:", error);
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
This PR address issue #140.

The data related to a Event is exported into a spreadsheet (.xlsx file), including:
Heat tab: Display the heat distribution for the event.
Lane tab: Display the lane distribution for the event.


### Implementation

1.  Backend
   - **backend/api/views/download/DownloadHeats.py**
This view includes a `post` method to get all the information related to the provided `event_id`. It retrieves its heats and lane distribution data.
It calls a method to generate an excel file with these information and return it as a response.

The method to generate the file is called `generate_excel_for_event_heats`. It receives the data and create the file structure, populate the file and format the content. It returns the response including the file as an attachment.


   - **backend/api/urls.py**
A new path was defined to call the `post` method in `DownloadHeats` view:
`download-heats-details/<int:event_id>/
`

2. Frontend
   - **frontend/src/SmmApi.jsx**
the following `downloadHeatDetails(swimMeetName, eventName, eventId)` was  added. Sends a POST request to generate a file with all the heats information for a specified event (eventId).

   - **frontend/src/Event/MeetEventDisplay.jsx**
      - The Download Heats Details  action button was added. It is visible if the number of heats is > 0.
      - The `handleDownloadDetails` function was created to handle the download button click. It calls the downloadHeatDetails function to make the request to the API to generate the xlsx file for the specified event id. In case of an error, it display an alert to inform the user about it.
  
   - **frontend/src/Event/EventDetails.jsx**
      - Add Download Details button in the ItemPaginationBar. It is disable if the number of heats is equal to 0.
      - The onDownload prop is added to handle the Download Details onClick event.

### UI

The Download Heats Details icon is display for the event with heats:

<img width="1296" alt="Screenshot 2024-11-11 at 9 31 20 PM" src="https://github.com/user-attachments/assets/b9b499a8-4633-4548-9c39-a155e5f44c4d">

The Download Details button is display for an event with heats:
<img width="1689" alt="Screenshot 2024-11-11 at 9 33 14 PM" src="https://github.com/user-attachments/assets/2b03ceee-b770-4c1f-9d59-5ddd813124d6">

The Download Details button is disabled for an event with no heats:

<img width="1282" alt="Screenshot 2024-11-11 at 9 33 03 PM" src="https://github.com/user-attachments/assets/58cb455a-34b8-44d2-8b4f-0d80ababff8c">



