### PR TITLE
BE - Endpoint to download all heats by meet

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -15,7 +15,7 @@ from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
 from api.views.HeatView import HeatBatchView, HeatDetailView
 from api.views.LaneView import LaneBatchView, LaneDetailView
-from api.views.download.DownloadHeats import DownloadAllHeatsByEvent
+from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 
 from rest_framework.routers import SimpleRouter
 
@@ -50,6 +50,8 @@ urlpatterns = [
          LaneDetailView.as_view(), name='lane-detail'),
     path('download-heats-details/<int:event_id>/',
          DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
+    path('download-all-heats-details/<int:meet_id>/',
+         DownloadAllHeatsByMeet.as_view(), name='download-meet-heats-details')
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
This PR address issue #154 .

The data related to all the event's heat details of the swim meet is exported into a spreadsheet (.xlsx file), including:
Heat tab: Display the heat distribution for each event in the swim meet.
Lane tab: Display the lane distribution for each event in the swim meet.

### Implementation

1.  Backend
   - **backend/api/views/download/DownloadHeats.py**
Add new class view (`DownloadAllHeatsByMeet`).
This view includes a `post` method to get the information related to the provided `meet_id`. It retrieves its event and all the heats and lane distribution data for each of them.
It calls the method `create_excel_file_for_heats_details` to generate an excel file with these information and return it as a response.


   - **backend/api/urls.py**
A new path was defined to call the `post` method in `DownloadAllHeatsByMeet` view:
`download-all-heats-details/<int:meet_id>/
`

### Swagger
The endpoint `/api/download-all-heats-details/{meet_id}/` is listed in the Download section:

![Screenshot 2024-11-17 at 1 25 00 PM](https://github.com/user-attachments/assets/93538bf6-a592-4c45-8b61-c7eec90ff5c0)

Try the endpoint with meet_id = 1. The response is a link to download the xlsx file:

![Screenshot 2024-11-17 at 1 25 22 PM](https://github.com/user-attachments/assets/2fd35fcd-ab10-4733-986b-efbf086be30b)

After downloading the file, it can be imported to google sheets. This is a view for each spreadsheet (by heat and by lane):
By heat:
![Screenshot 2024-11-17 at 1 27 25 PM](https://github.com/user-attachments/assets/0786c710-f973-4c93-99d0-6facbbbd1a75)

By lane:
![Screenshot 2024-11-17 at 1 27 45 PM](https://github.com/user-attachments/assets/bff654e1-9acf-43a0-8408-710d1a022a19)
