### PR TITLE
FE- Download Heat Details for all events in a swim meet

### DIFF
--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -203,7 +203,7 @@ class DownloadAllHeatsByEvent(APIView):
 
         swim_meet_details = {
             'name': swim_meet_instance.name,
-            'date': swim_meet_instance.date.strftime('%m-%d-%Y'),
+            'date': swim_meet_instance.date.strftime('%m/%d/%Y'),
             'location': swim_meet_instance.site.name
         }
 
@@ -289,7 +289,7 @@ class DownloadAllHeatsByMeet(APIView):
 
         swim_meet_details = {
             'name': swim_meet_instance.name,
-            'date': swim_meet_instance.date,
+            'date': swim_meet_instance.date.strftime('%m/%d/%Y'),
             'location': swim_meet_instance.site.name
         }
 

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -265,6 +265,7 @@ const MeetEventDisplay = () => {
                   <MyButton
                     label={"Download Heats for All Events"}
                     onClick={handleDownloadDetailsForAllEvents}
+                    disabled={eventData.length === 0}
                   >
                     <DownloadIcon />
                   </MyButton>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -77,7 +77,8 @@ const MeetEventDisplay = () => {
   };
 
   const handleDownloadDetailsForEvent = async (id) => {
-    let currentEvent = selectedEventIndex ? selectedEventIndex : Number(id);
+    let currentEvent =
+      selectedEventIndex !== null ? selectedEventIndex : Number(id);
     try {
       await SmmApi.downloadHeatDetailsForEvent(
         meetData.name,

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -75,14 +75,24 @@ const MeetEventDisplay = () => {
   const handleRankingClick = (id) => {
     console.log("Ranking ...");
   };
-  const handleDownloadDetails = async (id) => {
+
+  const handleDownloadDetailsForEvent = async (id) => {
     let currentEvent = selectedEventIndex ? selectedEventIndex : Number(id);
     try {
-      await SmmApi.downloadHeatDetails(
+      await SmmApi.downloadHeatDetailsForEvent(
         meetData.name,
         eventData[currentEvent].name,
         eventData[currentEvent].id
       );
+    } catch (error) {
+      console.error("Download failed:", error);
+      alert("There was an error downloading the file. Please try again.");
+    }
+  };
+
+  const handleDownloadDetailsForAllEvents = async (id) => {
+    try {
+      await SmmApi.downloadHeatDetailsForSwimMeet(meetData.name, meetData.id);
     } catch (error) {
       console.error("Download failed:", error);
       alert("There was an error downloading the file. Please try again.");
@@ -119,7 +129,7 @@ const MeetEventDisplay = () => {
     {
       name: "Download Heats Details",
       icon: <DownloadIcon />,
-      onClick: handleDownloadDetails,
+      onClick: handleDownloadDetailsForEvent,
       tip: "Download Heats Details",
       visible: (row) => row.original.total_num_heats > 0,
     },
@@ -222,7 +232,7 @@ const MeetEventDisplay = () => {
             onPrevious={handlePreviousEvent}
             onNext={handleNextEvent}
             onGenerate={handleGenerateButton}
-            onDownload={handleDownloadDetails}
+            onDownload={handleDownloadDetailsForEvent}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
           />
@@ -240,11 +250,26 @@ const MeetEventDisplay = () => {
               alignItems="center"
               justifyContent="space-between"
             >
-              <Box sx={{ marginLeft: 5 }}>
-                <MyButton label={"Event"} onClick={handleAddNew}>
-                  <AddIcon />
-                </MyButton>
-              </Box>
+              <Stack
+                sx={{ marginLeft: 5 }}
+                direction="row"
+                alignItems="center"
+                spacing={2}
+              >
+                <Box>
+                  <MyButton label={"Event"} onClick={handleAddNew}>
+                    <AddIcon />
+                  </MyButton>
+                </Box>
+                <Box>
+                  <MyButton
+                    label={"Download Heats for All Events"}
+                    onClick={handleDownloadDetailsForAllEvents}
+                  >
+                    <DownloadIcon />
+                  </MyButton>
+                </Box>
+              </Stack>
               <Box className={"searchBox"} sx={{ marginRight: 5 }}></Box>
             </Stack>
             <br />

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -200,7 +200,7 @@ export class SmmApi {
     });
   }
 
-  static async downloadHeatDetails(swimMeetName, eventName, eventId) {
+  static async downloadHeatDetailsForEvent(swimMeetName, eventName, eventId) {
     try {
       const response = await axios.post(
         `${BASE_URL}/download-heats-details/${eventId}/`,
@@ -218,6 +218,39 @@ export class SmmApi {
 
       // Set the file name
       link.setAttribute("download", `${swimMeetName}_${eventName}.xlsx`);
+
+      document.body.appendChild(link);
+      link.click();
+
+      // Cleanup
+      link.parentNode.removeChild(link);
+    } catch (error) {
+      console.error("Error downloading heats file:", error);
+      throw error;
+    }
+  }
+
+  static async downloadHeatDetailsForSwimMeet(swimMeetName, meetId) {
+    try {
+      const response = await axios.post(
+        `${BASE_URL}/download-all-heats-details/${meetId}/`,
+        {},
+        {
+          headers: getConfig(),
+          responseType: "blob", // Important for file downloads
+        }
+      );
+
+      // Create a URL for the blob and trigger the download
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+
+      // Set the file name
+      link.setAttribute(
+        "download",
+        `${swimMeetName}- All Event Heat Details.xlsx`
+      );
 
       document.body.appendChild(link);
       link.click();


### PR DESCRIPTION
This PR address issue #153 and related to #154.

A button in the Swim Meet Display should allow the user to download the heats details for all the events in the Swim Meet.

### Implementation

   - **frontend/src/SmmApi.jsx**
the `downloadHeatDetailsForSwimMeet(swimMeetName, meetId)` was  added. Sends a POST request to generate a file with all the heats information for all the events in the specified meet id (meetId).

   - **frontend/src/Event/MeetEventDisplay.jsx**
      - The Download Heats For All Events  button was added. It is disable if the number of events is 0.
      - The `handleDownloadDetailsForAllEvents` function was created to handle the download button click. It calls the `downloadHeatDetailsForSwimMeet` function to make the request to the API to generate the xlsx file  with the heats details for all the events in the specified event id. In case of an error, it display an alert to inform the user about it.
  
### UI

The Download Heats for All Events button is enabled for the swim meet with events:
![Screenshot 2024-11-17 at 3 24 00 PM](https://github.com/user-attachments/assets/b5c04149-798b-4dfb-b788-7de8ab7c305b)


The Download Heats for All Events button is disabled for the swim meet with no events:

![Screenshot 2024-11-17 at 3 37 31 PM](https://github.com/user-attachments/assets/41232ee0-b1c3-4744-a529-c45e754c0a56)

