### PR TITLE
BE- Fix Handle None values in HeatDurationField

### DIFF
--- a/backend/api/CustomField.py
+++ b/backend/api/CustomField.py
@@ -1,18 +1,20 @@
 from rest_framework import serializers
-       
+
 
 class BlankableTimeField(serializers.TimeField):
     def to_internal_value(self, value):
         if value == '':
             return None
         return super().to_internal_value(value)
-    
+
+
 class BlankableIntegerField(serializers.IntegerField):
     def to_internal_value(self, value):
         if value == '':
             return None
         return super().to_internal_value(value)
-    
+
+
 class HeatDurationField(serializers.DurationField):
     def to_internal_value(self, value):
         """
@@ -26,8 +28,10 @@ class HeatDurationField(serializers.DurationField):
             -A positive duration
         """
         # Disqualified
-        if value == 'DQ':
-            return serializers.DurationField().to_internal_value('400 0:0.0') 
+        if value is None or value == '':
+            return None
+        elif value == 'DQ':
+            return serializers.DurationField().to_internal_value('400 0:0.0')
         # No show
         elif value == 'NS':
             return serializers.DurationField().to_internal_value('300 0:0.0')
@@ -38,7 +42,9 @@ class HeatDurationField(serializers.DurationField):
             return super().to_internal_value(value)
 
     def to_representation(self, value):
-        if value == serializers.DurationField().to_internal_value('400 0:0.0'):
+        if value is None:
+            return None
+        elif value == serializers.DurationField().to_internal_value('400 0:0.0'):
             return 'DQ'
         elif value == serializers.DurationField().to_internal_value('300 0:0.0'):
             return 'NS'


### PR DESCRIPTION
This issue fixes #158 

The custom HeatDurationField is not handling None values causing an error when having a None value for a heat_time.

`KeyError: "Got KeyError when attempting to get a value for field `heat_time` on serializer `LaneSerializer`.\nThe serializer field might be named incorrectly and not match any attribute or key on the `dict` instance.\nOriginal exception text was: 'heat_time'."`

**Implementation**


1. **backend/api/CustomField.py**
Add a validation for None value in to_internal_value and to_representation, returning None in these cases.