### PR TITLE
Fix-Display heat_time in Lane information

### DIFF
--- a/backend/api/serializers/HeatDisplaySerializer.py
+++ b/backend/api/serializers/HeatDisplaySerializer.py
@@ -24,7 +24,7 @@ class HeatSerializer(serializers.ModelSerializer):
 class LaneSerializer(serializers.ModelSerializer):
     athlete_full_name = serializers.SerializerMethodField()
     # Setting write_only directly on the field as HeatDurationField is not a model field
-    heat_time = HeatDurationField(write_only=True)
+    heat_time = HeatDurationField()
 
     class Meta:
         model = Heat
@@ -34,7 +34,6 @@ class LaneSerializer(serializers.ModelSerializer):
             'athlete': {'read_only': True},
             'athlete_full_name': {'read_only': True},
         }
-
 
 
     def get_athlete_full_name(self, instance):
@@ -49,7 +48,6 @@ class LaneSerializer(serializers.ModelSerializer):
         #Updates heat_time
         instance.heat_time = validated_data.get('heat_time')
         instance.save()
-
     
         #Register the time on TimeRecord
         athlete = validated_data.get('athlete', instance.athlete)

--- a/backend/api/views/LaneView.py
+++ b/backend/api/views/LaneView.py
@@ -42,7 +42,7 @@ class LaneBatchView(APIView):
                             "id": None,
                             "num_heat": heat,
                             "athlete": None,
-                            "seed_time": None
+                            "heat_time": None
                     })
         
                 # Serialize the heats using LaneSerializer
@@ -97,7 +97,7 @@ class LaneDetailView(APIView):
                             "id": None,
                             "num_heat": heat,
                             "athlete": None,
-                            "seed_time": None
+                            "heat_time": None
                     })
         
                 # Serialize the heats using LaneSerializer
@@ -119,14 +119,17 @@ class LaneDetailView(APIView):
                             value=[
                                     {
                                         "num_heat": 1,
+                                        "athlete": 11,
                                         "heat_time": "45.90"
                                     },
                                     {
                                         "num_heat": 2,
+                                        "athlete": 12,
                                         "heat_time": "NS"
                                     },
                                     {
                                         "num_heat": 3,
+                                        "athlete": 12,
                                         "heat_time": "36.67"
                                     }
                             ]


### PR DESCRIPTION
This PR is address issue #159 

### Implemetation

Followed the steps described on issue #159.

### Swagger

Heat time is now visible
![image](https://github.com/user-attachments/assets/582f4313-a61f-4310-a491-663d528f0b20)

