### PR TITLE
BE- Endpoint to update heat time(s)

### DIFF
--- a/backend/api/serializers/HeatDisplaySerializer.py
+++ b/backend/api/serializers/HeatDisplaySerializer.py
@@ -51,7 +51,7 @@ class LaneSerializer(serializers.ModelSerializer):
         event_type = event_instance.event_type
         swim_meet = event_instance.swim_meet
 
-        time_record, created = TimeRecord.objects.update_or_create(
+        TimeRecord.objects.update_or_create(
             athlete=instance.athlete,
             event_type=event_type,
             swim_meet=swim_meet,

--- a/backend/api/serializers/HeatDisplaySerializer.py
+++ b/backend/api/serializers/HeatDisplaySerializer.py
@@ -9,10 +9,10 @@ class HeatSerializer(serializers.ModelSerializer):
     seed_time = HeatDurationField()
     heat_time = HeatDurationField()
 
-
     class Meta:
         model = Heat
-        fields = ('id', 'lane_num', 'athlete', 'athlete_full_name', 'seed_time', 'heat_time')
+        fields = ('id', 'lane_num', 'athlete',
+                  'athlete_full_name', 'seed_time', 'heat_time')
 
     def get_athlete_full_name(self, instance):
         if isinstance(instance, Heat):
@@ -20,6 +20,7 @@ class HeatSerializer(serializers.ModelSerializer):
             if athlete:
                 return athlete.full_name
         return None
+
 
 class LaneSerializer(serializers.ModelSerializer):
     athlete_full_name = serializers.SerializerMethodField()
@@ -28,13 +29,13 @@ class LaneSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Heat
-        fields = ('id', 'num_heat', 'athlete', 'athlete_full_name', 'heat_time')
+        fields = ('id', 'num_heat', 'athlete',
+                  'athlete_full_name', 'heat_time')
 
         extra_kwargs = {
             'athlete': {'read_only': True},
             'athlete_full_name': {'read_only': True},
         }
-
 
     def get_athlete_full_name(self, instance):
         if isinstance(instance, Heat):
@@ -42,26 +43,28 @@ class LaneSerializer(serializers.ModelSerializer):
             if athlete:
                 return athlete.full_name
         return None
-    
+
     @transaction.atomic
     def update(self, instance, validated_data):
-        #Updates heat_time
-        instance.heat_time = validated_data.get('heat_time')
-        instance.save()
-    
-        #Register the time on TimeRecord
-        athlete = validated_data.get('athlete', instance.athlete)
+        # Register the time on TimeRecord
         event_instance = self.context['event']
         event_type = event_instance.event_type
         swim_meet = event_instance.swim_meet
-        TimeRecord.objects.create(
-            athlete = athlete,
-            event_type = event_type,
-            swim_meet = swim_meet,
-            date = swim_meet.date,
-            time = instance.heat_time
+
+        time_record, created = TimeRecord.objects.update_or_create(
+            athlete=instance.athlete,
+            event_type=event_type,
+            swim_meet=swim_meet,
+            time=instance.heat_time,
+            defaults={
+                'date': swim_meet.date,
+                'time': validated_data.get('heat_time'),
+                'athlete': instance.athlete,
+                'event_type': event_type,
+                'swim_meet': swim_meet
+            }
         )
+        # Updates heat_time
+        instance.heat_time = validated_data.get('heat_time')
+        instance.save()
         return instance
-
-
-

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -14,7 +14,7 @@ from api.views.TimeRecordView import TimeRecordViewSet
 from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
 from api.views.HeatView import HeatBatchView, HeatDetailView
-from api.views.LaneView import LaneBatchView, LaneDetailView
+from api.views.LaneView import LaneBatchView, LaneDetailView, UpdateHeatTimeView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 
 from rest_framework.routers import SimpleRouter
@@ -51,7 +51,9 @@ urlpatterns = [
     path('download-heats-details/<int:event_id>/',
          DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
     path('download-all-heats-details/<int:meet_id>/',
-         DownloadAllHeatsByMeet.as_view(), name='download-meet-heats-details')
+         DownloadAllHeatsByMeet.as_view(), name='download-meet-heats-details'),
+    path('event_lane/update_heat_times/',
+         UpdateHeatTimeView.as_view(), name='update-heat-time')
 ]
 
 urlpatterns += router.urls

--- a/backend/api/views/LaneView.py
+++ b/backend/api/views/LaneView.py
@@ -12,26 +12,27 @@ from django.db import transaction
 class LaneBatchView(APIView):
     @extend_schema(summary="Retrieves the heat assignments for each lane for a given event")
     def get(self, request, event_id):
-        #Get event instance
+        # Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get num_lanes
+
+        # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
-        
+
         max_num_heat = event_instance.total_num_heats
 
         if max_num_heat:
             lanes_data = []
-            for lane_num in range (1,num_lanes+1):
+            for lane_num in range(1, num_lanes+1):
                 # Retrieve all heats for the given event_id and lane_num
-                heats = Heat.objects.filter(event_id=event_id, lane_num=lane_num)
+                heats = Heat.objects.filter(
+                    event_id=event_id, lane_num=lane_num)
                 heats_data = []
                 for heat in range(1, max_num_heat + 1):
                     heat_data = heats.filter(num_heat=heat).first()
@@ -43,50 +44,51 @@ class LaneBatchView(APIView):
                             "num_heat": heat,
                             "athlete": None,
                             "heat_time": None
-                    })
-        
+                        })
+
                 # Serialize the heats using LaneSerializer
                 serializer = LaneSerializer(heats_data, many=True)
                 lanes_data.append({
-                "id": lane_num,
-                "lane_name": f"Lane {lane_num}",
-                "heats": serializer.data
-            })
+                    "id": lane_num,
+                    "lane_name": f"Lane {lane_num}",
+                    "heats": serializer.data
+                })
             return Response({
-            'count': num_lanes,
-            'results': lanes_data
-        }, status=status.HTTP_200_OK)
+                'count': num_lanes,
+                'results': lanes_data
+            }, status=status.HTTP_200_OK)
         else:
             return Response({
-            'count': 0,
-            'results': []
-        }, status=status.HTTP_200_OK)
+                'count': 0,
+                'results': []
+            }, status=status.HTTP_200_OK)
 
 
 @extend_schema(tags=['Heat'], request=LaneSerializer())
 class LaneDetailView(APIView):
     @extend_schema(summary="Displays heats distribution on a specific lane for a given event")
     def get(self, request, event_id, lane_num):
-        #Get event instance
+        # Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get number of lanes on the event
+
+        # Get number of lanes on the event
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get number of heats on the event
+
+        # Get number of heats on the event
         max_num_heat = event_instance.total_num_heats
 
         if max_num_heat:
-            if 1<= lane_num <= num_lanes:
+            if 1 <= lane_num <= num_lanes:
                 # Retrieve all heats for the given event_id and lane_num
-                heats = Heat.objects.filter(event_id=event_id, lane_num=lane_num)
+                heats = Heat.objects.filter(
+                    event_id=event_id, lane_num=lane_num)
                 heats_data = []
                 for heat in range(1, max_num_heat + 1):
                     heat_data = heats.filter(num_heat=heat).first()
@@ -98,8 +100,8 @@ class LaneDetailView(APIView):
                             "num_heat": heat,
                             "athlete": None,
                             "heat_time": None
-                    })
-        
+                        })
+
                 # Serialize the heats using LaneSerializer
                 serializer = LaneSerializer(heats_data, many=True)
                 response_data = {
@@ -112,57 +114,41 @@ class LaneDetailView(APIView):
         else:
             return Response({'message': 'This event does not have heats yet'}, status=status.HTTP_200_OK)
 
+
+@extend_schema(tags=['Heat'], request=LaneSerializer())
+class UpdateHeatTimeView(APIView):
+
     @extend_schema(examples=[
-                        OpenApiExample(
-                            "Example Value",
-                            summary="Example of a PUT request",
-                            value=[
-                                    {
-                                        "num_heat": 1,
-                                        "athlete": 11,
-                                        "heat_time": "45.90"
-                                    },
-                                    {
-                                        "num_heat": 2,
-                                        "athlete": 12,
-                                        "heat_time": "NS"
-                                    },
-                                    {
-                                        "num_heat": 3,
-                                        "athlete": 12,
-                                        "heat_time": "36.67"
-                                    }
-                            ]
-                        )
-                    ], 
-                   summary="Updates the recorded times for all heats on a specific lane for a given event")
+        OpenApiExample(
+            "Example Value",
+            summary="Example of a PUT request",
+            value=[
+                {
+                    "heat_id": 1,
+                    "heat_time": "45.90"
+                },
+                {
+                    "heat_id": 2,
+                    "heat_time": "45.90"
+                },
+                {
+                    "heat_id": 3,
+                    "heat_time": "45.90"
+                }
+            ]
+        )
+    ],
+        summary="Updates the recorded times for all heats listed")
     @transaction.atomic
-    def put(self, request, event_id, lane_num): 
-        # Given all the athletes on a lane, update the heat_time and register the time on TimeRecord.
-        try:
-            event_instance = MeetEvent.objects.get(id=event_id)
-        except MeetEvent.DoesNotExist:
-            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get num_lanes
-        try:
-            swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
-        except:
-            return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
-        
-        if 1<= lane_num <= num_lanes: 
-            result_data = request.data
-            for heat_record in result_data:
-                if heat_record['athlete'] is not None:
-                    num_heat = heat_record['num_heat']
-                    try:
-                        heat_instance = Heat.objects.get(event=event_instance,num_heat=num_heat, lane_num=lane_num)
-                        serializer = LaneSerializer(instance=heat_instance, data=heat_record, context={'event': event_instance}, partial=True)
-                        if serializer.is_valid(raise_exception=True):
-                            serializer.save()
-                    except Heat.DoesNotExist:
-                        return Response({'error': 'Heat not found'}, status=status.HTTP_404_NOT_FOUND)
-            return Response({'message': 'Heats updated successfully'}, status=status.HTTP_200_OK)
-        else:
-            return Response({'error': 'There is not a lane with that number'}, status=status.HTTP_404_NOT_FOUND)
+    def put(self, request):
+        for heat_record in request.data:
+            try:
+                heat_instance = Heat.objects.get(id=heat_record['heat_id'])
+                event_instance = heat_instance.event
+                serializer = LaneSerializer(instance=heat_instance, data=heat_record, context={
+                                            'event': event_instance}, partial=True)
+                if serializer.is_valid(raise_exception=True):
+                    serializer.save()
+            except Heat.DoesNotExist:
+                return Response({'error': 'Heat not found'}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'message': 'Heats updated successfully'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR address issue #162 

We need to update a single heat time or multiple heat times at once. When updating or creating a `heat_time`, we need to also update/create a corresponding record in _TimeRecord_.

**Implementation**
`heat_time` is a field of `Heat`, with the `heat_id` we can access all the fields needed to search for the corresponding record in `TimeRecord`. If it's not found, the record is created in `TimeRecord` with the `heat_time` and also `heat_time` is updated for the corresponding `Heat` record(`heat_id`).

1. **backend/api/serializers/HeatDisplaySerializer.py**
The `update` function was refactored to access to the event details associated with the Heat, then update or create a record in `TimeRecord` with these details and the `heat_time`.
Lastly, update the `heat_time` for the `Heat` instance(`heat_id`).

2. **backend/api/views/LaneView.pyy**
Add a new View, `UpdateHeatTimeView`, that can receive a list with one or more heat times to update.

3. **backend/api/urls.py**
A new path was defined to call the `put` method in `UpdateHeatTimeView` view:
`event_lane/update_heat_times/
`

### Swagger
The endpoint `/api/event_lane/update_heat_times/` is listed under the Heat section:

![Screenshot 2024-11-17 at 10 26 18 PM](https://github.com/user-attachments/assets/97924542-de08-4395-bc5c-a3ca47e0bb02)
