### PR TITLE
BE - Event Results display (New PR)

### DIFF
--- a/backend/api/CustomFilter.py
+++ b/backend/api/CustomFilter.py
@@ -1,0 +1,53 @@
+from api.models import Group
+from rest_framework.exceptions import ValidationError
+from rest_framework import status
+from django.db.models import Func, Value, F, IntegerField
+from django.utils import timezone
+
+
+"""
+This function is used to filter a queryset by group.
+When the queryset comes from the `Athlete` model, the 
+argument `athlete` is not needed.
+When the queryset comes from a model that contains
+`Athlete` as a foreign key, the argument `athlete` should 
+be set to `False`.
+"""
+def filter_by_group(group_id, queryset, athlete=True):
+    # Get the group instance with id group_id
+    try:
+        group_instance = Group.objects.get(id=group_id)
+    except Group.DoesNotExist:
+        raise ValidationError({'error': "Group does not exist"}, code=status.HTTP_400_BAD_REQUEST)
+
+    # Distinguishes between the `Athlete` model and other models.
+    if athlete:
+        athlete_field = ""
+    else:
+        athlete_field = "athlete__"
+
+    # Create an age field on `Athlete`.
+    queryset = queryset.annotate(
+        age=Func(
+            Value("year"),
+            Func(Value(timezone.now().date()), F(
+                f"{athlete_field}date_of_birth"), function="age"),
+            function="date_part",
+            output_field=IntegerField()
+        )
+    )
+
+    # Filter by the gender specified in the group.
+    gender = group_instance.gender
+    if gender != 'MX':
+        queryset = queryset.filter(**{f"{athlete_field}gender": gender})
+
+    # Filter by age range of the group.
+    min_age = group_instance.min_age
+    max_age = group_instance.max_age
+    if max_age is not None:
+        queryset = queryset.filter(age__lte=max_age)
+    if min_age is not None:
+        queryset = queryset.filter(age__gte=min_age)
+
+    return queryset

--- a/backend/api/serializers/EventResultSerializer.py
+++ b/backend/api/serializers/EventResultSerializer.py
@@ -1,0 +1,12 @@
+from api.models import Heat
+from rest_framework import serializers
+from api.CustomField import HeatDurationField
+
+
+class EventResultSerializer(serializers.ModelSerializer):
+    athlete_full_name = serializers.ReadOnlyField(source="athlete.full_name")
+    heat_time = HeatDurationField()
+
+    class Meta:
+        model = Heat
+        fields = ('id', 'athlete', 'athlete_full_name', 'heat_time')

--- a/backend/api/serializers/EventResultSerializer.py
+++ b/backend/api/serializers/EventResultSerializer.py
@@ -6,7 +6,8 @@ from api.CustomField import HeatDurationField
 class EventResultSerializer(serializers.ModelSerializer):
     athlete_full_name = serializers.ReadOnlyField(source="athlete.full_name")
     heat_time = HeatDurationField()
+    rank = serializers.IntegerField(allow_null=True)
 
     class Meta:
         model = Heat
-        fields = ('id', 'athlete', 'athlete_full_name', 'heat_time')
+        fields = ('id', 'rank', 'athlete', 'athlete_full_name', 'heat_time')

--- a/backend/api/serializers/HeatDisplaySerializer.py
+++ b/backend/api/serializers/HeatDisplaySerializer.py
@@ -24,7 +24,6 @@ class HeatSerializer(serializers.ModelSerializer):
 
 class LaneSerializer(serializers.ModelSerializer):
     athlete_full_name = serializers.SerializerMethodField()
-    # Setting write_only directly on the field as HeatDurationField is not a model field
     heat_time = HeatDurationField()
 
     class Meta:

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -15,6 +15,7 @@ from api.views.MeetEventView import MeetEventView
 from api.views.AtheleteSeedTimeView import AthleteSeedTimeView
 from api.views.HeatView import HeatBatchView, HeatDetailView
 from api.views.LaneView import LaneBatchView, LaneDetailView, UpdateHeatTimeView
+from api.views.EventResultView import EventResultView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 
 from rest_framework.routers import SimpleRouter
@@ -48,6 +49,8 @@ urlpatterns = [
          LaneBatchView.as_view(), name='lanes-event'),
     path('event_lane/<int:event_id>/<int:lane_num>/',
          LaneDetailView.as_view(), name='lane-detail'),
+    path('event_result/<int:event_id>/',
+         EventResultView.as_view(), name='event_result'),
     path('download-heats-details/<int:event_id>/',
          DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
     path('download-all-heats-details/<int:meet_id>/',

--- a/backend/api/views/EventResultView.py
+++ b/backend/api/views/EventResultView.py
@@ -8,7 +8,7 @@ from api.CustomFilter import filter_by_group
 
 
 
-@extend_schema(tags=['Swim Meet - Events'])
+@extend_schema(tags=['Results'])
 class EventResultView(APIView):
     @extend_schema(parameters =[OpenApiParameter(name="group_id", type=int)],summary="Displays the results of an event")
     def get(self, request, event_id):

--- a/backend/api/views/EventResultView.py
+++ b/backend/api/views/EventResultView.py
@@ -28,4 +28,19 @@ class EventResultView(APIView):
         group_id = self.request.query_params.get('group_id')
         if group_id is not None:
             queryset = filter_by_group(group_id, queryset, False)
-        return queryset.order_by('heat_time')
+
+        results = list(queryset.order_by('heat_time', 'athlete__last_name', 'athlete__first_name'))
+        
+        if results:
+            current_rank = 1
+            previous_time = -1
+            for i, result in enumerate(results):
+                if result.heat_time in ["NS", "DQ", None]:
+                    break 
+                elif result.heat_time == previous_time:
+                    result.rank = current_rank
+                else:
+                    current_rank = i + 1
+                    result.rank = current_rank
+                previous_time = result.heat_time
+        return results

--- a/backend/api/views/EventResultView.py
+++ b/backend/api/views/EventResultView.py
@@ -1,0 +1,31 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from api.models import MeetEvent, Heat
+from api.serializers.EventResultSerializer import EventResultSerializer
+from drf_spectacular.utils import extend_schema, OpenApiParameter
+from api.CustomFilter import filter_by_group
+
+
+
+@extend_schema(tags=['Swim Meet - Events'])
+class EventResultView(APIView):
+    @extend_schema(parameters =[OpenApiParameter(name="group_id", type=int)],summary="Displays the results of an event")
+    def get(self, request, event_id):
+        #Get event instance
+        try:
+            event_instance = MeetEvent.objects.get(id=event_id)
+        except MeetEvent.DoesNotExist:
+            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        #Return all heats record with event = even_instance order by heat_time
+        data = self.get_queryset(event_instance)
+        serializer = EventResultSerializer(data, many=True)
+        return Response(serializer.data)
+
+    def get_queryset(self, event_instance):
+        queryset = Heat.objects.filter(event=event_instance)
+        group_id = self.request.query_params.get('group_id')
+        if group_id is not None:
+            queryset = filter_by_group(group_id, queryset, False)
+        return queryset.order_by('heat_time')

--- a/frontend/.vite/deps_temp_d21870ef/package.json
+++ b/frontend/.vite/deps_temp_d21870ef/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This PR address issue #59 

### Implementation

1. **backend/api/CustomFilter.py**

Created an auxiliar function to filter by group

2. **backend/api/serializers/EventResultSerializer.py**

-  Based on `Head` Model, displays `id`, `rank`,  `athlete`, `athlete_full_name`, and `heat_time`.

-  rank is an integer, allow to be null, calculated when we get the queryset.

-  **"NS"**, **"DQ"** and `null` heat times do not get a rank and appear at the end of the list.

3. **backend/api/views/EventResultView.py**

-  Uses `EventResultSerializer` and, given an event, displays all the results of the event ranked by `heat_time`.

-  Filtering by group is possible.

4. **backend/api/urls.py**

The endpoint `event_result/<int:event_id>/` was added. Uses EventResultView.