### PR TITLE
BE - Filter By Group on GroupViewSet

### DIFF
--- a/backend/api/views/GroupView.py
+++ b/backend/api/views/GroupView.py
@@ -1,16 +1,57 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
 from api.models import Group
 from api.serializers.GroupSerializer import GroupSerializer
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.types import OpenApiTypes
+from django.db.models import Q
 import logging
 
 logger = logging.getLogger('django')
 
 
 @extend_schema(tags=['Group'])
+@extend_schema(methods=['GET'],
+               parameters=[
+                OpenApiParameter(
+                    name='filtering_group_id',
+                    description='ID of the filtering group to apply custom filtering logic.',
+                    required=False,
+                    type=OpenApiTypes.INT,
+                    location=OpenApiParameter.QUERY,
+                )
+               ],
+)
 class GroupViewSet(viewsets.ModelViewSet):
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
     permission_classes = [IsAuthenticated]
     http_method_names = ['get', 'post', 'patch', 'delete']
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        filtering_group_id = self.request.query_params.get('filtering_group_id', None)
+        print(filtering_group_id)
+        if not filtering_group_id:
+            return queryset
+
+        try:
+            filtering_group = Group.objects.get(id=filtering_group_id)
+        except Group.DoesNotExist:
+            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        filter_gender = filtering_group.gender
+        filter_min_age = filtering_group.min_age
+        filter_max_age = filtering_group.max_age
+        if filter_gender != "MX":
+            queryset = queryset.filter(gender = filter_gender)
+        if filter_max_age and filter_min_age:
+            queryset = queryset.filter(Q(min_age__lte=filter_max_age) | Q(max_age__gte=filter_min_age) )
+        elif filter_min_age and filter_max_age is None:
+            queryset = queryset.filter(min_age__gte = filter_min_age)
+        elif filter_max_age and filter_min_age is None:
+            queryset = queryset.filter(max_age__lte = filter_max_age)
+        return queryset.exclude(id=filtering_group.id)

--- a/backend/api/views/GroupView.py
+++ b/backend/api/views/GroupView.py
@@ -51,7 +51,7 @@ class GroupViewSet(viewsets.ModelViewSet):
         if filter_max_age and filter_min_age:
             queryset = queryset.filter(Q(min_age__lte=filter_max_age) | Q(max_age__gte=filter_min_age) )
         elif filter_min_age and filter_max_age is None:
-            queryset = queryset.filter(min_age__gte = filter_min_age)
+            queryset = queryset.filter(Q(min_age__gte=filter_min_age) | Q(max_age__gte=filter_min_age))
         elif filter_max_age and filter_min_age is None:
-            queryset = queryset.filter(max_age__lte = filter_max_age)
+            queryset = queryset.filter(Q(max_age__lte=filter_max_age) | Q(min_age__lte=filter_min_age))
         return queryset.exclude(id=filtering_group.id)

--- a/backend/api/views/GroupView.py
+++ b/backend/api/views/GroupView.py
@@ -1,7 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from rest_framework import status
+from rest_framework.exceptions import NotFound
 from api.models import Group
 from api.serializers.GroupSerializer import GroupSerializer
 from drf_spectacular.utils import extend_schema, OpenApiParameter
@@ -41,7 +40,7 @@ class GroupViewSet(viewsets.ModelViewSet):
         try:
             filtering_group = Group.objects.get(id=filtering_group_id)
         except Group.DoesNotExist:
-            return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+            raise NotFound(detail="Filtering group not found")
 
         filter_gender = filtering_group.gender
         filter_min_age = filtering_group.min_age
@@ -53,5 +52,5 @@ class GroupViewSet(viewsets.ModelViewSet):
         elif filter_min_age and filter_max_age is None:
             queryset = queryset.filter(Q(min_age__gte=filter_min_age) | Q(max_age__gte=filter_min_age))
         elif filter_max_age and filter_min_age is None:
-            queryset = queryset.filter(Q(max_age__lte=filter_max_age) | Q(min_age__lte=filter_min_age))
+            queryset = queryset.filter(Q(max_age__lte=filter_max_age) | Q(min_age__lte=filter_max_age))
         return queryset.exclude(id=filtering_group.id)


### PR DESCRIPTION
This PR addresses issue #169 

### Implementation

Changes in **backend/api/views/GroupView.py**

1. **`filtering_group_id` Parameter in GET Method**
- Added Swagger schema documentation to display the `filtering_group_id` query parameter in the GET method.

2. **`get_queryset` Method Logic**

- Validates the existence of the filtering_group_id parameter:
   - If it does not exist, the `super().get_queryset()` is returned as-is.
   - If it exists, the following filtering logic is applied to the `super().get_queryset()`:
      - **Gender Filtering**:
         -  If the group's gender is not "Mixed", filter by the gender value.
      - **Age Range Filtering**
         -  For groups with a specified `min_age` and `max_age`:
            -  Intervals with a right limit (`max_age`) greater than or equal to `min_age`.   [min_age, right_limit] max_age]   
            -  Intervals with a left limit (`min_age`) less than or equal to `max_age`.   [min_age, [left_limit max_age] 
         - For groups with only a specified `min_age`:
            - The left limit (`min_age`) is greater than or equal to the given `min_age`.   [min_age,   [left_limit         )
            - The right limit (`max_age`) is greater than or equal to the given `min_age`.   [min_age,   right_limit]         )
         - For groups with only a specified `max_age`: 
            - The right limit (`max_age`) is less than or equal to the given max_age. (           right_limit] ,max_age]
            - The left limit (`min_age`) is less than or equal to the given `max_age`.  (       [left_limit,    ,max_age]
     - Excluding the Filtering Group 
         - The `filtering_group` itself is excluded from the `queryset` to prevent it from appearing in the results. 


