### PR TITLE
FE- Add Close button on Tabs

### DIFF
--- a/frontend/src/Tests/TestTabPanel.jsx
+++ b/frontend/src/Tests/TestTabPanel.jsx
@@ -16,8 +16,20 @@ const TestTabs = () => {
       {
         label: `New Tab ${prevTabs.length + 1}`,
         content: <div>New Content {prevTabs.length + 1}</div>,
+        close: true
       },
     ]);
+  };
+
+  const handleRemoveTab = (index) => {
+    setTabs((prevTabs) => prevTabs.filter((_, i) => i !== index));
+    setSelectedTab((prevSelected) =>
+      prevSelected === index
+        ? Math.max(0, index - 1)
+        : prevSelected > index
+        ? prevSelected - 1
+        : prevSelected
+    );
   };
 
   return (
@@ -29,6 +41,7 @@ const TestTabs = () => {
         tabs={tabs}
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
+        onRemoveTab={handleRemoveTab}
       />
     </div>
   );

--- a/frontend/src/Tests/TestTabPanel.jsx
+++ b/frontend/src/Tests/TestTabPanel.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import TabPanel from "../components/Common/TabPanel";
 import SwimMeetDisplay from "../SwimMeet/SwimMeetDisplay";
-import AddSwimMeet from "../SwimMeet/AddSwimMeet";
 
 const TestTabs = () => {
   const [tabs, setTabs] = useState([

--- a/frontend/src/Tests/TestTabPanel.jsx
+++ b/frontend/src/Tests/TestTabPanel.jsx
@@ -1,34 +1,35 @@
 import { useState } from "react";
-import { MoveUp as BackIcon, Add as AddIcon } from "@mui/icons-material";
 import TabPanel from "../components/Common/TabPanel";
 import SwimMeetDisplay from "../SwimMeet/SwimMeetDisplay";
 import AddSwimMeet from "../SwimMeet/AddSwimMeet";
 
 const TestTabs = () => {
-  const handleByHeatsClick = () => {
-    console.log("Heats");
-  };
+  const [tabs, setTabs] = useState([
+    { label: "Heats", content: <SwimMeetDisplay /> },
+  ]);
+  const [selectedTab, setSelectedTab] = useState(0);
 
-  const handleByLanesClick = () => {
-    console.log("Lanes");
+  const handleAddTab = () => {
+    setSelectedTab(tabs.length);
+    setTabs((prevTabs) => [
+      ...prevTabs,
+      {
+        label: `New Tab ${prevTabs.length + 1}`,
+        content: <div>New Content {prevTabs.length + 1}</div>,
+      },
+    ]);
   };
-
-  const tabs = [
-    {
-      label: "Heats",
-      onClick: handleByHeatsClick,
-      content: <SwimMeetDisplay />,
-    },
-    {
-      label: "Lanes",
-      onClick: handleByLanesClick,
-      content: <AddSwimMeet />,
-    },
-  ];
 
   return (
     <div className={"test"}>
-      <TabPanel tabs={tabs} />
+      <button onClick={handleAddTab} style={{ marginBottom: "10px" }}>
+        Add Tab
+      </button>
+      <TabPanel
+        tabs={tabs}
+        selectedTab={selectedTab}
+        setSelectedTab={setSelectedTab}
+      />
     </div>
   );
 };

--- a/frontend/src/components/Common/TabPanel.jsx
+++ b/frontend/src/components/Common/TabPanel.jsx
@@ -32,6 +32,7 @@ export default function TabPanel({ tabs, selectedTab, setSelectedTab, onRemoveTa
           {tabs.map((tab, index) => (
             <Tab
               key={index}
+              component="div"
               label={
                 <Box
                   sx={{

--- a/frontend/src/components/Common/TabPanel.jsx
+++ b/frontend/src/components/Common/TabPanel.jsx
@@ -1,11 +1,8 @@
 import * as React from "react";
-import { Tabs, Tab, Box, useTheme } from "@mui/material";
+import { Tabs, Tab, Box, useTheme, IconButton } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 
-export default function TabPanel({
-  tabs,
-  selectedTab,
-  setSelectedTab,
-}) {
+export default function TabPanel({ tabs, selectedTab, setSelectedTab, onRemoveTab }) {
   const theme = useTheme();
 
   const onTabChange = (event, newValue) => {
@@ -14,7 +11,8 @@ export default function TabPanel({
 
   return (
     <Box sx={{ width: "100%" }}>
-      <Box sx={{
+      <Box
+        sx={{
           borderLeft: 2,
           borderRight: 2,
           borderTop: 2,
@@ -22,23 +20,49 @@ export default function TabPanel({
           borderColor: theme.palette.primary.main,
           borderTopLeftRadius: "6px",
           borderTopRightRadius: "6px",
-        }}>
+        }}
+      >
         <Tabs
           value={selectedTab}
           onChange={onTabChange}
           aria-label="tabs"
           variant="fullWidth"
+          scrollButtons="auto"
         >
           {tabs.map((tab, index) => (
             <Tab
               key={index}
-              label={tab.label}
+              label={
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                  }}
+                >
+                  <span>{tab.label}</span>
+                  {tab.close && (
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRemoveTab(index);
+                      }}
+                    >
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </Box>
+              }
               sx={{
                 color: theme.palette.primary.main,
                 fontWeight: "bold",
-                borderRight: index !== tabs.length - 1 ? `2.5px solid ${theme.palette.primary.main}` : "none", 
+                borderRight:
+                  index !== tabs.length - 1
+                    ? `2.5px solid ${theme.palette.primary.main}`
+                    : "none",
                 "&.Mui-selected": {
-                  color: theme.palette.primary.contrastText, 
+                  color: theme.palette.primary.contrastText,
                   backgroundColor: theme.palette.primary.main,
                   fontWeight: "bold",
                 },

--- a/frontend/src/components/Common/TabPanel.jsx
+++ b/frontend/src/components/Common/TabPanel.jsx
@@ -35,7 +35,8 @@ export default function TabPanel({
               label={tab.label}
               sx={{
                 color: theme.palette.primary.main,
-                fontWeight: "bold", 
+                fontWeight: "bold",
+                borderRight: index !== tabs.length - 1 ? `2.5px solid ${theme.palette.primary.main}` : "none", 
                 "&.Mui-selected": {
                   color: theme.palette.primary.contrastText, 
                   backgroundColor: theme.palette.primary.main,


### PR DESCRIPTION
This PR addresses issue #172 

### Implementation

1. **frontend/src/components/Common/TabPanel.jsx**

- Added support for a new `onRemoveTab` prop, which is a function triggered when a tab is closed. The tab index is passed as a parameter.
- For tabs with the close attribute set to true, a close button is now rendered.
- The close button invokes the `onRemoveTab` function when clicked.
- Added a visual divider (using a border) to separate tabs for better clarity.


2. **frontend/src/Tests/TestTabPanel.jsx**

- Initially, the `TabPanel` contains a single tab without a close attribute.
- Added a button to dynamically add new tabs. These dynamically added tabs have the close attribute set to true, making them render a close button.
- The last created tab is automatically selected after being added.
- Implemented functions to handle:
  -  **Adding Tabs**: Dynamically adds tabs with the close attribute.
  - **Closing Tabs**: Removes tabs when the close button is clicked.


### UI Preview

- Initial state
![image](https://github.com/user-attachments/assets/b6d7f366-d37a-4a76-a92e-09ad33ad2332)


- After adding one tab
![image](https://github.com/user-attachments/assets/a184160e-e425-4aba-b7b2-29f39d14ff11)



- After adding 5 tab
![image](https://github.com/user-attachments/assets/ac8ba184-c650-4a51-8cd0-70caaa200e41)


- Tab 4 was removed
![image](https://github.com/user-attachments/assets/deb3f3f1-6a13-46bd-bbfd-236ef1ba0ac4)


