### PR TITLE
FE-Add API method to retrieve event results

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
     path('event_lane/<int:event_id>/<int:lane_num>/',
          LaneDetailView.as_view(), name='lane-detail'),
     path('event_result/<int:event_id>/',
-         EventResultView.as_view(), name='event_result'),
+         EventResultView.as_view(), name='event-result'),
     path('download-heats-details/<int:event_id>/',
          DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
     path('download-all-heats-details/<int:meet_id>/',

--- a/backend/api/views/EventResultView.py
+++ b/backend/api/views/EventResultView.py
@@ -5,6 +5,7 @@ from api.models import MeetEvent, Heat
 from api.serializers.EventResultSerializer import EventResultSerializer
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from api.CustomFilter import filter_by_group
+from datetime import timedelta
 
 
 
@@ -35,8 +36,8 @@ class EventResultView(APIView):
             current_rank = 1
             previous_time = -1
             for i, result in enumerate(results):
-                if result.heat_time in ["NS", "DQ", None]:
-                    break 
+                if result.heat_time in [timedelta(days=300), timedelta(days=400), None]:
+                    break
                 elif result.heat_time == previous_time:
                     result.rank = current_rank
                 else:

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -262,4 +262,20 @@ export class SmmApi {
       throw error;
     }
   }
+
+  static async getEventResults(eventId, groupId) {
+    let url = `${BASE_URL}/event_result/${eventId}/?`;
+    const extraParams = new URLSearchParams();
+
+    if (groupId) {
+      extraParams.set("group_id", groupId);
+    }
+
+    url += extraParams.toString();
+
+    let res = await axios.get(url, {
+      headers: getConfig(),
+    });
+    return res.data;
+  }
 }


### PR DESCRIPTION
This PR addresses issue #175 

### Implementation

1. **frontend/src/SmmApi.jsx**

- Added the method `getEventResults(eventId, groupId)` to retrieve the results of a given event. This method supports optional filtering by group ID.

2. **backend/api/views/EventResultView.py**
-  **Issue Identified**: While testing `getEventResults(eventId, groupId)`, it was discovered that "NS" (No Show) and "DQ" (Disqualified) entries were being ranked incorrectly. This occurred because, prior to serialization, "NS" and "DQ" were represented as `timedelta` intervals instead of strings.
- **Fix**: Updated the get_queryset method to check for specific timedelta intervals (timedelta(days=300) for "NS" and timedelta(days=400) for "DQ") to ensure these entries are not assigned a rank.

3. **backend/api/urls.py**

- Changed the name of the path `event_result/<int:event_id>/` to `event-result` for consistency with other URL naming conventions in the project.