### PR TITLE
FE-Add API method to register heat times

### DIFF
--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -264,7 +264,7 @@ export class SmmApi {
   }
 
   static async registerHeatTimes(data) {
-    return await axios.post(`${BASE_URL}/event_lane/update_heat_times/`, data, {
+    return await axios.put(`${BASE_URL}/event_lane/update_heat_times/`, data, {
       headers: getConfig(),
     });
   }

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -262,4 +262,10 @@ export class SmmApi {
       throw error;
     }
   }
+
+  static async registerHeatTimes(data) {
+    return await axios.post(`${BASE_URL}/event_lane/update_heat_times/`, data, {
+      headers: getConfig(),
+    });
+  }
 }


### PR DESCRIPTION
This PR addresses issue #165 

### Description

This PR adds a new method in the `SmmApi` class to handle API request to  register heat times. 

### Implementation
In the `frontend/src/SmmApi.jsx` file, the following method was added:

- `registerHeatTimes`: Sends a PUT request to register(update) a heat time.
