### PR TITLE
FE- Fix DQ/NS heat time display

### DIFF
--- a/frontend/src/utils/helperFunctions.js
+++ b/frontend/src/utils/helperFunctions.js
@@ -1,14 +1,15 @@
-export function formatSeedTime(seedTime){
-    if (!seedTime) return null;
-    if (seedTime === "NT") return "NT";
-    const timeParts = seedTime.split(":");
-    const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
-    if (timeParts[0] !== "00") {
-      return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
-    }
-    if (timeParts[1] !== "00") {
-      const minutes = parseInt(timeParts[1], 10);
-      return `${minutes}:${secondsAndMillis}`;
-    }
-    return `${secondsAndMillis}`;
-  };
+export function formatSeedTime(seedTime) {
+  if (!seedTime) return null;
+  if (seedTime === "NT" || seedTime === "DQ" || seedTime === "NS")
+    return seedTime;
+  const timeParts = seedTime.split(":");
+  const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
+  if (timeParts[0] !== "00") {
+    return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
+  }
+  if (timeParts[1] !== "00") {
+    const minutes = parseInt(timeParts[1], 10);
+    return `${minutes}:${secondsAndMillis}`;
+  }
+  return `${secondsAndMillis}`;
+}


### PR DESCRIPTION
This PR is address issue #180  

When the heat time is DQ or NS, the value is displayed as:
DQ:undefined:NaN 
NS:undefined:NaN

### Implemetation
This issue is because the `formatSeedTime` is called for each heat time but this function is not handling the DQ and NS value.

- **_frontend/src/utils/helperFunctions.js_**
The `formatSeedTime` was updated adding a validation for seed time equals to DQ or NS. In these cases, the same value (DQ/NS) is returned.

<img width="1557" alt="Screenshot 2024-11-26 at 7 45 55 AM" src="https://github.com/user-attachments/assets/29e2e073-9e5b-458a-a37d-e2982693aaa5">

