### PR TITLE
FE-GenericTable new features

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import TestExpandableTable from "./Tests/TestExpandableTable";
 import TestConditionalRender from "./Tests/TestConditionalRender";
 import TestSelectTable from "./Tests/TestSelectTable";
 import TestSeedTimeForm from "./Tests/TestSeedTimeForm";
+import TestResults from "./Tests/TestResults";
 
 function App() {
   const NotFound = () => {
@@ -49,6 +50,7 @@ function App() {
       <Route path="/tests/test-select-table" element={<TestSelectTable />} />
       <Route path="/tests/test-conditional-render" element={<TestConditionalRender />} />
       <Route path="/tests/test-seed-time-form" element={<TestSeedTimeForm />} />
+      <Route path="/tests/test-results" element={<TestResults />} />
     </Routes>
   );
 }

--- a/frontend/src/Tests/TestResults.jsx
+++ b/frontend/src/Tests/TestResults.jsx
@@ -1,0 +1,102 @@
+import "../App.css";
+import { useState } from "react";
+import GenericTable from "../components/Common/GenericTable";
+import { Box } from "@mui/material";
+
+const testData = [
+  {
+    id: 2,
+    rank: 1,
+    athlete_full_name: "Ana Gomez",
+    heat_time: "37.81",
+  },
+  {
+    id: 10,
+    rank: 2,
+    athlete_full_name: "Anna Anderson",
+    heat_time: "38.54",
+  },
+  {
+    id: 16,
+    rank: 3,
+    athlete_full_name: "Ava Wilson",
+    heat_time: "39.81",
+  },
+  {
+    id: 4,
+    rank: 3,
+    athlete_full_name: "Elena Lopez",
+    heat_time: "40.22",
+  },
+  {
+    id: 12,
+    rank: 5,
+    athlete_full_name: "Ellie Yuan",
+    heat_time: "41.84",
+  },
+  {
+    id: 8,
+    rank: 6,
+    athlete_full_name: "Kyla Smith",
+    heat_time: "42.55",
+  },
+  {
+    id: 6,
+    rank: null,
+    athlete_full_name: "Laura Sanchez",
+    heat_time: "NS",
+  },
+  {
+    id: 15,
+    athlete_full_name: "Olivia Davis",
+    heat_time: "DQ",
+  },
+  {
+    id: 11,
+    athlete_full_name: "Sofia Avila",
+    heat_time: "DQ",
+  },
+];
+
+const columns = [
+  {
+    accessorKey: "rank",
+    header: "Rank",
+    size: 100,
+  },
+  {
+    accessorKey: "athlete_full_name",
+    header: "Athlete",
+    size: 250,
+  },
+  {
+    accessorKey: "heat_time",
+    header: "Heat time",
+    size: 150,
+  },
+];
+
+const TestResults = () => {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        width: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        className={"test"}
+      >
+        <GenericTable data={testData} columns={columns} AddSearch={true} />
+      </Box>
+    </div>
+  );
+};
+
+export default TestResults;

--- a/frontend/src/Tests/TestResults.jsx
+++ b/frontend/src/Tests/TestResults.jsx
@@ -140,7 +140,7 @@ const TestResults = () => {
         <GenericTable
           data={testData}
           columns={columns}
-          AddSearch={true}
+          enableSearch={true}
           getRowStyle={rowHighlight}
         />
       </Box>

--- a/frontend/src/Tests/TestResults.jsx
+++ b/frontend/src/Tests/TestResults.jsx
@@ -48,11 +48,13 @@ const testData = [
   },
   {
     id: 15,
+    rank: null,
     athlete_full_name: "Olivia Davis",
     heat_time: "DQ",
   },
   {
     id: 11,
+    rank: null,
     athlete_full_name: "Sofia Avila",
     heat_time: "DQ",
   },
@@ -76,6 +78,48 @@ const columns = [
   },
 ];
 
+const rowHighlight = (row) => {
+  const rank = row.original.rank;
+  if (rank === 1) {
+    return {
+      backgroundColor: "#ffd700",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === 2) {
+    return {
+      backgroundColor: "#c0c0c0",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === 3) {
+    return {
+      backgroundColor: "#DAAA5E",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === null) {
+    return {
+        backgroundColor: "#f0f0f0",
+      "& *": {
+        color: "#a0a0a0",
+        fontStyle: "italic",
+        fontWeight: "lighter"
+      },
+    };
+  }
+  return {};
+};
+
 const TestResults = () => {
   return (
     <div
@@ -93,7 +137,12 @@ const TestResults = () => {
         alignItems="center"
         className={"test"}
       >
-        <GenericTable data={testData} columns={columns} AddSearch={true} />
+        <GenericTable
+          data={testData}
+          columns={columns}
+          AddSearch={true}
+          getRowStyle={rowHighlight}
+        />
       </Box>
     </div>
   );

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -4,7 +4,7 @@ import {
 } from "material-react-table";
 import { Box, IconButton, Tooltip, useTheme } from "@mui/material";
 
-const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch, getRowStyle }) => {
+const GenericTable = ({ data, columns, actions, notRecordsMessage, enableSearch, getRowStyle }) => {
   const enableActions = actions;
   const theme = useTheme();
   const table = useMaterialReactTable({
@@ -22,8 +22,8 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch, ge
     enableSorting: false,
     enableRowActions: enableActions,
     positionActionsColumn: "last",
-    initialState: { density: "compact", showGlobalFilter: AddSearch ? AddSearch : false },
-    enableTopToolbar: AddSearch ? AddSearch : false,
+    initialState: { density: "compact", showGlobalFilter: enableSearch ? enableSearch : false },
+    enableTopToolbar: enableSearch ? enableSearch : false,
     enableToolbarInternalActions: false,
     enableBottomToolbar: false,
     enableColumnActions: false,

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -4,7 +4,7 @@ import {
 } from "material-react-table";
 import { Box, IconButton, Tooltip, useTheme } from "@mui/material";
 
-const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch }) => {
+const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch, getRowStyle }) => {
   const enableActions = actions;
   const theme = useTheme();
   const table = useMaterialReactTable({
@@ -16,6 +16,9 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch }) 
         color: theme.palette.primary.contrastText,
       },
     },
+    muiTableBodyRowProps: ({ row }) => ({
+      sx: getRowStyle ? getRowStyle(row) : {},
+    }),
     enableSorting: false,
     enableRowActions: enableActions,
     positionActionsColumn: "last",

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -4,7 +4,7 @@ import {
 } from "material-react-table";
 import { Box, IconButton, Tooltip, useTheme } from "@mui/material";
 
-const GenericTable = ({ data, columns, actions, notRecordsMessage }) => {
+const GenericTable = ({ data, columns, actions, notRecordsMessage, AddSearch }) => {
   const enableActions = actions;
   const theme = useTheme();
   const table = useMaterialReactTable({
@@ -19,8 +19,9 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage }) => {
     enableSorting: false,
     enableRowActions: enableActions,
     positionActionsColumn: "last",
-    initialState: { density: "compact" },
-    enableTopToolbar: false,
+    initialState: { density: "compact", showGlobalFilter: AddSearch ? AddSearch : false },
+    enableTopToolbar: AddSearch ? AddSearch : false,
+    enableToolbarInternalActions: false,
     enableBottomToolbar: false,
     enableColumnActions: false,
     enablePagination: false,


### PR DESCRIPTION
This PR addresses issue #178.

**Implementation**

1. Updates to **GenericTable**

- File: **frontend/src/components/Common/GenericTable.jsx**
- Changes:
  - New props:
     -   `enableSearch` (boolean): Enables global search functionality in the Material React Table when set to true.
     -  `getRowStyle` (function): Allows dynamic modification of row styles.

2. Demonstrating the Changes

-  Added a new TestResults component with a dedicated route (http://localhost:3000/tests/test-results).
-  Functionality:
    -  Displays a ranking table with a search filter.
    -  Highlights the top 3 rankings.
    - Applies a subtler style to rows with "NS" (No Show) and "DQ" (Disqualified) statuses.

![image](https://github.com/user-attachments/assets/8b629ece-5098-4cf2-b415-2299e14d4a00)

