### PR TITLE
FE- Save Heat Times (First Time)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -22,7 +22,7 @@
   padding: 10px;
   min-width: 300px;
   height: 30%;
-  width: 42%;
+  width: 48%;
   border: 1px solid lightblue;
   border-radius: 5px;
 }

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -64,6 +64,32 @@ const EventDetails = ({
     };
   }, [eventId]);
 
+  const handleLaneDataUpdate = (updatedData) => {
+    //Update the data by lane
+    const updatedLaneData = laneData.map((lane) => {
+      const updatedHeats = lane.heats.map((heat) => {
+        const updatedHeat = updatedData.find((p) => p.heat_id === heat.id);
+        return updatedHeat
+          ? { ...heat, heat_time: updatedHeat.heat_time }
+          : heat;
+      });
+      return { ...lane, heats: updatedHeats };
+    });
+    setLaneData(updatedLaneData);
+
+    //Update the data by heat
+    const updatedHeatData = heatData.map((heat) => {
+      const updatedLanes = heat.lanes.map((lane) => {
+        const updatedLane = updatedData.find((p) => p.heat_id === lane.id);
+        return updatedLane
+          ? { ...lane, heat_time: updatedLane.heat_time }
+          : lane;
+      });
+      return { ...heat, lanes: updatedLanes };
+    });
+    setHeatData(updatedHeatData);
+  };
+
   //What is needed for the itemPaginationBar
   const label = "Event " + eventName;
   const extraButtons = [
@@ -84,12 +110,7 @@ const EventDetails = ({
   const tabs = [
     {
       label: "By Heat",
-      content: (
-        <DetailsByHeat
-        key={"heats" + eventId}
-        heatData={heatData}
-      />
-      ),
+      content: <DetailsByHeat key={"heats" + eventId} heatData={heatData} />,
     },
     {
       label: "By Lane",
@@ -98,6 +119,7 @@ const EventDetails = ({
           key={"lanes" + eventId}
           numLanes={numLanes}
           laneData={laneData}
+          onLaneDataUpdate={handleLaneDataUpdate}
         />
       ),
     },

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -64,7 +64,7 @@ const EventDetails = ({
     };
   }, [eventId, reloadDetailsTrigger]);
 
-  const handleLaneDataUpdate = (updatedData) => {
+  const handleLaneDataUpdate = () => {
     setReloadDetailsTrigger((prev) => prev + 1);
   };
 

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -30,7 +30,7 @@ const EventDetails = ({
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
   const [selectedTab, setSelectedTab] = useState(0);
-
+  const [reloadDetailsTrigger, setReloadDetailsTrigger] = useState(0);
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading
     ? "Data upload failed. Please try again!"
@@ -62,32 +62,10 @@ const EventDetails = ({
     return () => {
       ignore = true;
     };
-  }, [eventId]);
+  }, [eventId, reloadDetailsTrigger]);
 
   const handleLaneDataUpdate = (updatedData) => {
-    //Update the data by lane
-    const updatedLaneData = laneData.map((lane) => {
-      const updatedHeats = lane.heats.map((heat) => {
-        const updatedHeat = updatedData.find((p) => p.heat_id === heat.id);
-        return updatedHeat
-          ? { ...heat, heat_time: updatedHeat.heat_time }
-          : heat;
-      });
-      return { ...lane, heats: updatedHeats };
-    });
-    setLaneData(updatedLaneData);
-
-    //Update the data by heat
-    const updatedHeatData = heatData.map((heat) => {
-      const updatedLanes = heat.lanes.map((lane) => {
-        const updatedLane = updatedData.find((p) => p.heat_id === lane.id);
-        return updatedLane
-          ? { ...lane, heat_time: updatedLane.heat_time }
-          : lane;
-      });
-      return { ...heat, lanes: updatedLanes };
-    });
-    setHeatData(updatedHeatData);
+    setReloadDetailsTrigger((prev) => prev + 1);
   };
 
   //What is needed for the itemPaginationBar

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -3,6 +3,14 @@ import {
   Close as CloseIcon,
   Save as SaveIcon,
 } from "@mui/icons-material";
+import {
+  Dialog,
+  DialogContent,
+  DialogActions,
+  Button,
+  Alert,
+} from "@mui/material";
+
 import React, { useState, useMemo } from "react";
 import { SmmApi } from "../SmmApi.jsx";
 import ExpandableTable from "../components/Common/ExpandableTable.jsx";
@@ -10,8 +18,9 @@ import HeatTimeForm from "./HeatTimeForm.jsx";
 import { formatSeedTime } from "../utils/helperFunctions.js";
 import { useForm } from "react-hook-form";
 
-const DetailsByLane = ({ numLanes, laneData }) => {
+const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
   const [editMainTableRowIndexes, setEditMainTableRowIndexes] = useState([]);
+  const [error, setError] = useState(null);
   const laneFormHooks = Array.from({ length: numLanes }).map(() =>
     useForm({ mode: "onChange" })
   );
@@ -75,19 +84,32 @@ const DetailsByLane = ({ numLanes, laneData }) => {
     });
   };
 
+  const handleEditClickOnSubTable = (row) => {
+    console.log("Heat to update", row);
+  };
+
   const handleSave = (rowIndex) => {
     const laneFormState = laneFormHooks[rowIndex];
     if (laneFormState) {
-      laneFormState.handleSubmit((data) => {
-        // TODO (Issue #150): Implement API call to persist the data
-        // Currently, 'data' is an object containing key-value pairs
-        // where each key represents a heat ID and the corresponding value
-        // is the entered heat time for that specific heat.
-        console.log("Submitting data for row:", rowIndex, "with values:", data);
-        laneFormState.reset();
-        setEditMainTableRowIndexes((prevIndexes) =>
-          prevIndexes.filter((index) => index !== Number(rowIndex))
-        );
+      laneFormState.handleSubmit(async (data) => {
+        const payload = Object.entries(data).map(([heatId, heatTime]) => ({
+          heat_id: Number(heatId),
+          heat_time:
+            heatTime === "DQ" || heatTime === "NS"
+              ? heatTime
+              : `00:${heatTime}`,
+        }));
+
+        try {
+          await SmmApi.registerHeatTimes(payload);
+          onLaneDataUpdate(payload);
+          laneFormState.reset();
+          setEditMainTableRowIndexes((prevIndexes) =>
+            prevIndexes.filter((index) => index !== Number(rowIndex))
+          );
+        } catch (error) {
+          setError("Failed to update heat times. Please try again.");
+        }
       })();
     } else {
       console.log("No useForm");
@@ -100,6 +122,9 @@ const DetailsByLane = ({ numLanes, laneData }) => {
     );
   };
 
+  const handleDialogClose = () => {
+    setError(null);
+  };
   const actionsLaneMainTable = [
     {
       name: "Edit",
@@ -129,6 +154,16 @@ const DetailsByLane = ({ numLanes, laneData }) => {
     },
   ];
 
+  const actionsLaneSubTable = [
+    {
+      name: "Edit",
+      icon: <EditIcon />,
+      onClick: handleEditClickOnSubTable,
+      tip: "Edit heat time",
+      visible: (row) => !!row.original.heat_time,
+    },
+  ];
+
   return (
     <div>
       <ExpandableTable
@@ -137,7 +172,19 @@ const DetailsByLane = ({ numLanes, laneData }) => {
         actions={actionsLaneMainTable}
         getSubTableColumns={getSubLaneTableColumns}
         subData={"heats"}
+        subTableActions={actionsLaneSubTable}
       />
+
+      <Dialog open={!!error} onClose={handleDialogClose}>
+        <DialogContent>
+          <Alert severity="error">{error}</Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDialogClose} color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -96,7 +96,7 @@ const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
 
         try {
           await SmmApi.registerHeatTimes(payload);
-          onLaneDataUpdate(payload);
+          onLaneDataUpdate();
           laneFormState.reset();
           setEditMainTableRowIndexes((prevIndexes) =>
             prevIndexes.filter((index) => index !== Number(rowIndex))

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -106,7 +106,7 @@ const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
         }
       })();
     } else {
-      console.log("No useForm");
+      setError("Failed to update heat times. Please try again.");
     }
   };
 

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -1,22 +1,16 @@
 import {
-  Edit as EditIcon,
   Close as CloseIcon,
+  Edit as EditIcon,
   Save as SaveIcon,
 } from "@mui/icons-material";
-import {
-  Dialog,
-  DialogContent,
-  DialogActions,
-  Button,
-  Alert,
-} from "@mui/material";
-
-import React, { useState, useMemo } from "react";
-import { SmmApi } from "../SmmApi.jsx";
-import ExpandableTable from "../components/Common/ExpandableTable.jsx";
-import HeatTimeForm from "./HeatTimeForm.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
+import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { SmmApi } from "../SmmApi.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import ExpandableTable from "../components/Common/ExpandableTable.jsx";
+import { formatSeedTime } from "../utils/helperFunctions.js";
+import HeatTimeForm from "./HeatTimeForm.jsx";
 
 const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
   const [editMainTableRowIndexes, setEditMainTableRowIndexes] = useState([]);
@@ -177,7 +171,7 @@ const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
 
       <Dialog open={!!error} onClose={handleDialogClose}>
         <DialogContent>
-          <Alert severity="error">{error}</Alert>
+          <AlertBox type="error" message={error} />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleDialogClose} color="primary">

--- a/frontend/src/components/Common/ExpandableTable.jsx
+++ b/frontend/src/components/Common/ExpandableTable.jsx
@@ -10,6 +10,7 @@ const ExpandableTable = ({
   actions,
   getSubTableColumns,
   subData,
+  subTableActions,
 }) => {
   const enableActions = actions;
   const theme = useTheme();
@@ -94,6 +95,8 @@ const ExpandableTable = ({
             enableBottomToolbar={false}
             enableColumnActions={false}
             enablePagination={false}
+            enableRowActions={subTableActions}
+            positionActionsColumn="last"
             initialState={{
               density: "compact",
             }}
@@ -103,6 +106,41 @@ const ExpandableTable = ({
                 color: theme.palette.primary.contrastText,
               },
             }}
+            renderRowActions={({ row }) =>
+              subTableActions &&
+              subTableActions.map((action, index) => {
+                let shouldRender = true;
+                if (action.visible) {
+                  shouldRender = action.visible(row);
+                }
+                return (
+                  shouldRender && (
+                    <Tooltip
+                      key={index}
+                      title={action.tip}
+                      placement="top"
+                      arrow
+                      slotProps={{
+                        popper: {
+                          modifiers: [
+                            {
+                              name: "offset",
+                              options: {
+                                offset: [0, -20],
+                              },
+                            },
+                          ],
+                        },
+                      }}
+                    >
+                      <IconButton onClick={() => action.onClick(row.original)}>
+                        {action.icon}
+                      </IconButton>
+                    </Tooltip>
+                  )
+                );
+              })
+            }
           />
         </Box>
       );


### PR DESCRIPTION
This PR address issue #150 which is related to issue #149.


When clicking "Save" action, all the heat times on the lane should be register. The edit action on the main table should not be visible any more and for each row on the sub table a new edit button should appear.

### Implementation

1. **_frontend/src/Heat/DetailsByLane.jsx_**

  - Added a new prop `onLaneDataUpdate` to handle updating the heat times displayed on the tables after successfully saving them.
  - Call the API to save the heat times after clicking the save button.
  - In case of an error calling the API, an alert is displayed to notify the user.
  - Add `actionsLaneSubTable` with an Edit Action to be visible in a row when there is a registered heat time.

2. **_frontend/src/components/Common/ExpandableTable.jsx_**

  - Added a new prop `subTableActions` to allow the subtable include actions. 
  - The icons for the actions defined in the `subTableActions` are rendered.


3. **_frontend/src/Event/EventDetails.jsx_**

  - Implement `handleLaneDataUpdate`  function to handle updating the heat_time on `laneData` and `heatData` upon saving them in order to display them on the tables by lane and by heat . 
  - This function is passed as a value for prop `onLaneDataUpdate`.

### UI Preview

- Edit action in the main table is visible for lanes without heat times. 
- Edit action in the sub table is visible for the rows with heat times.

<img width="1720" alt="Screenshot 2024-12-01 at 11 31 33 PM" src="https://github.com/user-attachments/assets/006d22c9-e785-48a9-8eb8-dd2cd29547c2">

- Clicking edit on a Lane render a HeatTimeForm on rows with athletes. The user registers heat time for the athletes.
<img width="1425" alt="Screenshot 2024-12-01 at 11 32 06 PM" src="https://github.com/user-attachments/assets/e2f421fb-94ec-4fea-bd22-474d4b2e8229">


-  Clicking save registers the heat times and are now displayed on the table. The edit option is now displayed for these rows since there is a heat time registered for each one.
<img width="1548" alt="Screenshot 2024-12-01 at 11 32 24 PM" src="https://github.com/user-attachments/assets/7c3c732d-29b8-4af8-85ca-404c35afc811">

- The heat time is also displayed on the by heat table.
<img width="1648" alt="Screenshot 2024-12-01 at 11 32 45 PM" src="https://github.com/user-attachments/assets/3655cfbe-8b1e-4c7f-8ebb-a2b91f8cb27d">
