### PR TITLE
FE- Fix Time Format

### DIFF
--- a/frontend/src/Heat/DetailsByHeat.jsx
+++ b/frontend/src/Heat/DetailsByHeat.jsx
@@ -1,8 +1,7 @@
 import ExpandableTable from "../components/Common/ExpandableTable";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 
-
-const DetailsByHeat = ({ heatData}) => {
+const DetailsByHeat = ({ heatData }) => {
   //Need data for heat tables
   const mainHeatTableColumns = [
     {
@@ -28,13 +27,13 @@ const DetailsByHeat = ({ heatData}) => {
       accessorKey: "seed_time",
       header: "Seed Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
     },
     {
       accessorKey: "heat_time",
       header: "Heat Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
     },
   ];
 

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -7,7 +7,7 @@ import React, { useState, useMemo } from "react";
 import { SmmApi } from "../SmmApi.jsx";
 import ExpandableTable from "../components/Common/ExpandableTable.jsx";
 import HeatTimeForm from "./HeatTimeForm.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 import { useForm } from "react-hook-form";
 
 const DetailsByLane = ({ numLanes, laneData }) => {
@@ -41,7 +41,12 @@ const DetailsByLane = ({ numLanes, laneData }) => {
       accessorKey: "heat_time",
       header: "Heat Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
+      /* muiTableBodyCellProps: {
+        sx: {
+          textAlign: "right", 
+        },
+      }, */
     };
     const editHeatTimeColumn = {
       accessorKey: "heat_time",

--- a/frontend/src/Heat/GenerateHeats.jsx
+++ b/frontend/src/Heat/GenerateHeats.jsx
@@ -18,7 +18,7 @@ import GenericTable from "../components/Common/GenericTable.jsx";
 import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
 import SelectTable from "../components/Common/SelectTable.jsx";
 import MyIconButton from "../components/FormElements/MyIconButton.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 import UpdateSeedTime from "./UpdateSeedTime.jsx";
 
 // Constants for table columns
@@ -32,7 +32,7 @@ const availableColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 100,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
@@ -46,7 +46,7 @@ const selectedColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 100,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
@@ -60,16 +60,11 @@ const confirmSeedTimeColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 150,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
-const GenerateHeats = ({
-  eventName,
-  eventId,
-  onBack,
-  onProcessCompletion,
-}) => {
+const GenerateHeats = ({ eventName, eventId, onBack, onProcessCompletion }) => {
   //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
   const [selectedAthletes, setSelectedAthletes] = useState([]);
@@ -92,7 +87,9 @@ const GenerateHeats = ({
 
   // AlertBox variables
   let typeAlertCreateHeats = errorCreateHeat ? "error" : "success";
-  let messageCreateHeats = errorCreateHeat ? errorCreateHeat : "Heats created successfully!";
+  let messageCreateHeats = errorCreateHeat
+    ? errorCreateHeat
+    : "Heats created successfully!";
 
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading

--- a/frontend/src/Heat/UpdateSeedTime.jsx
+++ b/frontend/src/Heat/UpdateSeedTime.jsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import "../App.css";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { SmmApi } from "../SmmApi.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 import SeedTimeForm from "./SeedTimeForm.jsx";
 
 const UpdateSeedTime = ({ eventId, athlete, onUpdate, onCancel }) => {
@@ -73,7 +73,7 @@ const UpdateSeedTime = ({ eventId, athlete, onUpdate, onCancel }) => {
           handleCancel={onCancel}
           data={{
             athlete_name: athlete.athlete_full_name,
-            seed_time: formatSeedTime(athlete.seed_time),
+            seed_time: formatTime(athlete.seed_time),
           }}
           isValid={isValid}
         />

--- a/frontend/src/utils/helperFunctions.js
+++ b/frontend/src/utils/helperFunctions.js
@@ -11,7 +11,7 @@ export function formatTime(timeStr) {
     const minutes = parseInt(parts[1], 10);
     const [seconds, ms = "00"] = parts[2].split(".");
 
-    if (hours > 0) formattedTime.push(hours);
+    if (hours > 0) formattedTime.push(String(hours).padStart(2, "0"));
     formattedTime.push(String(minutes).padStart(2, "0"));
     formattedTime.push(
       `${String(seconds).padStart(2, "0")}.${ms.padEnd(2, "0").slice(0, 2)}`

--- a/frontend/src/utils/helperFunctions.js
+++ b/frontend/src/utils/helperFunctions.js
@@ -1,15 +1,33 @@
-export function formatSeedTime(seedTime) {
-  if (!seedTime) return null;
-  if (seedTime === "NT" || seedTime === "DQ" || seedTime === "NS")
-    return seedTime;
-  const timeParts = seedTime.split(":");
-  const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
-  if (timeParts[0] !== "00") {
-    return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
+export function formatTime(timeStr) {
+  if (!timeStr) return null;
+  if (timeStr === "NT" || timeStr === "DQ" || timeStr === "NS") return timeStr;
+
+  const parts = timeStr.split(":");
+  let formattedTime = [];
+
+  if (parts.length === 3) {
+    // HH:MM:SS.ms
+    const hours = parseInt(parts[0], 10);
+    const minutes = parseInt(parts[1], 10);
+    const [seconds, ms = "00"] = parts[2].split(".");
+
+    if (hours > 0) formattedTime.push(hours);
+    formattedTime.push(String(minutes).padStart(2, "0"));
+    formattedTime.push(
+      `${String(seconds).padStart(2, "0")}.${ms.padEnd(2, "0").slice(0, 2)}`
+    );
+  } else if (parts.length === 2) {
+    // MM:SS.ms
+    const minutes = parseInt(parts[0], 10);
+    const [seconds, ms = "00"] = parts[1].split(".");
+
+    if (minutes > 0) formattedTime.push(String(minutes).padStart(2, "0"));
+    formattedTime.push(
+      `${String(seconds).padStart(2, "0")}.${ms.padEnd(2, "0").slice(0, 2)}`
+    );
+  } else {
+    throw new Error("Invalid time format");
   }
-  if (timeParts[1] !== "00") {
-    const minutes = parseInt(timeParts[1], 10);
-    return `${minutes}:${secondsAndMillis}`;
-  }
-  return `${secondsAndMillis}`;
+
+  return formattedTime.join(":");
 }


### PR DESCRIPTION
This PR  fixes #187.

### Implementation
This issue is because the `formatSeedTime` separates the time in parts: hours, minutes and seconds with milliseconds. Then it converts the seconds with  milliseconds part to Float hence the leading zero is discarded i.e. 01.10 when converted to float results in 1.10. If minutes part is present, the seconds with milliseconds is concatenated to it leading to get a string like 1:1.10.

- **_frontend/src/utils/helperFunctions.js_**
The `formatSeedTime` function was renamed to `formatTime` and the code was refactored.
This function receives a time string, separates the time in parts: hours, minutes and seconds with milliseconds. Then separates the seconds and milliseconds. It takes only two digits for the milliseconds.
It forms a time string removing the hours part if its value is zero, returns a string with minutes and seconds with milliseconds concatenated.

Since the this helper functions was renamed from formatSeedTime to formatTime, its references were updated as well in the following files:

_**frontend/src/Heat/DetailsByHeat.jsx
frontend/src/Heat/DetailsByLane.jsx
frontend/src/Heat/GenerateHeats.jsx
frontend/src/Heat/UpdateSeedTime.jsx**_

###UI
<img width="1372" alt="Screenshot 2024-12-03 at 10 33 36 PM" src="https://github.com/user-attachments/assets/8bbcbde9-0c4a-4c56-b1fe-e7c9637da9e5">




