### PR TITLE
FE - Display results of an event.

### DIFF
--- a/backend/api/views/GroupView.py
+++ b/backend/api/views/GroupView.py
@@ -33,7 +33,6 @@ class GroupViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         filtering_group_id = self.request.query_params.get('filtering_group_id', None)
-        print(filtering_group_id)
         if not filtering_group_id:
             return queryset
 

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -128,6 +128,7 @@ const MeetEventDisplay = () => {
       icon: <RankingIcon />,
       onClick: handleRankingClick,
       tip: "Go to ranking",
+      visible: (row) => row.original.total_num_heats > 0,
     },
     {
       name: "Download Heats Details",

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -18,6 +18,7 @@ import Title from "../components/Common/Title.jsx";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import AddEvent from "./AddEvent.jsx";
 import EventDetails from "./EventDetails.jsx";
+import EventResults from "../Results/EventResults.jsx";
 
 const columns = [
   {
@@ -73,7 +74,8 @@ const MeetEventDisplay = () => {
   };
 
   const handleRankingClick = (id) => {
-    console.log("Ranking ...");
+    setSelectedEventIndex(Number(id));
+    setView("results");
   };
 
   const handleDownloadDetailsForEvent = async (id) => {
@@ -296,6 +298,18 @@ const MeetEventDisplay = () => {
             onBack={handleBackToEvents}
             onCreateHeats={handleAddHeatsToNewEvent}
             onCreateEvent={handleNewEventCreated}
+          />
+        );
+      case "results":
+        return (
+          <EventResults
+            eventName={currentEvent.name}
+            eventId={currentEvent.id}
+            onBack={handleBackToEvents}
+            onPrevious={handlePreviousEvent}
+            onNext={handleNextEvent}
+            disablePrevious={isFirstEvent}
+            disableNext={isLastEvent}
           />
         );
       default:

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -117,6 +117,13 @@ const MeetEventDisplay = () => {
       tip: "Go to Heats",
       visible: (row) => row.original.total_num_heats > 0,
     },
+    {
+      name: "Download Heats Details",
+      icon: <DownloadIcon />,
+      onClick: handleDownloadDetailsForEvent,
+      tip: "Download Heats Details",
+      visible: (row) => row.original.total_num_heats > 0,
+    },
     // {
     //   name: "Delete",
     //   icon: <DeleteIcon />,
@@ -130,13 +137,7 @@ const MeetEventDisplay = () => {
       tip: "Go to ranking",
       visible: (row) => row.original.total_num_heats > 0,
     },
-    {
-      name: "Download Heats Details",
-      icon: <DownloadIcon />,
-      onClick: handleDownloadDetailsForEvent,
-      tip: "Download Heats Details",
-      visible: (row) => row.original.total_num_heats > 0,
-    },
+    
   ];
 
   useEffect(() => {
@@ -306,6 +307,7 @@ const MeetEventDisplay = () => {
           <EventResults
             eventName={currentEvent.name}
             eventId={currentEvent.id}
+            groupId={currentEvent.group}
             onBack={handleBackToEvents}
             onPrevious={handlePreviousEvent}
             onNext={handleNextEvent}

--- a/frontend/src/Heat/DetailsByHeat.jsx
+++ b/frontend/src/Heat/DetailsByHeat.jsx
@@ -1,8 +1,7 @@
 import ExpandableTable from "../components/Common/ExpandableTable";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 
-
-const DetailsByHeat = ({ heatData}) => {
+const DetailsByHeat = ({ heatData }) => {
   //Need data for heat tables
   const mainHeatTableColumns = [
     {
@@ -28,13 +27,13 @@ const DetailsByHeat = ({ heatData}) => {
       accessorKey: "seed_time",
       header: "Seed Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
     },
     {
       accessorKey: "heat_time",
       header: "Heat Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
     },
   ];
 

--- a/frontend/src/Heat/DetailsByLane.jsx
+++ b/frontend/src/Heat/DetailsByLane.jsx
@@ -9,8 +9,8 @@ import { useForm } from "react-hook-form";
 import { SmmApi } from "../SmmApi.jsx";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import ExpandableTable from "../components/Common/ExpandableTable.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
 import HeatTimeForm from "./HeatTimeForm.jsx";
+import { formatTime } from "../utils/helperFunctions.js";
 
 const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
   const [editMainTableRowIndexes, setEditMainTableRowIndexes] = useState([]);
@@ -44,7 +44,12 @@ const DetailsByLane = ({ numLanes, laneData, onLaneDataUpdate }) => {
       accessorKey: "heat_time",
       header: "Heat Time",
       size: 100,
-      Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+      Cell: ({ cell }) => formatTime(cell.getValue()),
+      /* muiTableBodyCellProps: {
+        sx: {
+          textAlign: "right", 
+        },
+      }, */
     };
     const editHeatTimeColumn = {
       accessorKey: "heat_time",

--- a/frontend/src/Heat/GenerateHeats.jsx
+++ b/frontend/src/Heat/GenerateHeats.jsx
@@ -18,7 +18,7 @@ import GenericTable from "../components/Common/GenericTable.jsx";
 import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
 import SelectTable from "../components/Common/SelectTable.jsx";
 import MyIconButton from "../components/FormElements/MyIconButton.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 import UpdateSeedTime from "./UpdateSeedTime.jsx";
 
 // Constants for table columns
@@ -32,7 +32,7 @@ const availableColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 100,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
@@ -46,7 +46,7 @@ const selectedColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 100,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
@@ -60,16 +60,11 @@ const confirmSeedTimeColumns = [
     accessorKey: "seed_time",
     header: "Seed Time",
     size: 150,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 
-const GenerateHeats = ({
-  eventName,
-  eventId,
-  onBack,
-  onProcessCompletion,
-}) => {
+const GenerateHeats = ({ eventName, eventId, onBack, onProcessCompletion }) => {
   //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
   const [selectedAthletes, setSelectedAthletes] = useState([]);
@@ -92,7 +87,9 @@ const GenerateHeats = ({
 
   // AlertBox variables
   let typeAlertCreateHeats = errorCreateHeat ? "error" : "success";
-  let messageCreateHeats = errorCreateHeat ? errorCreateHeat : "Heats created successfully!";
+  let messageCreateHeats = errorCreateHeat
+    ? errorCreateHeat
+    : "Heats created successfully!";
 
   let typeAlertLoading = errorOnLoading ? "error" : "success";
   let messageOnLoading = errorOnLoading

--- a/frontend/src/Heat/UpdateSeedTime.jsx
+++ b/frontend/src/Heat/UpdateSeedTime.jsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import "../App.css";
 import AlertBox from "../components/Common/AlertBox.jsx";
 import { SmmApi } from "../SmmApi.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 import SeedTimeForm from "./SeedTimeForm.jsx";
 
 const UpdateSeedTime = ({ eventId, athlete, onUpdate, onCancel }) => {
@@ -73,7 +73,7 @@ const UpdateSeedTime = ({ eventId, athlete, onUpdate, onCancel }) => {
           handleCancel={onCancel}
           data={{
             athlete_name: athlete.athlete_full_name,
-            seed_time: formatSeedTime(athlete.seed_time),
+            seed_time: formatTime(athlete.seed_time),
           }}
           isValid={isValid}
         />

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -1,40 +1,345 @@
 import {
-    ContentPaste as BackIcon,
-    Build as BuildIcon,
-    Download as DownloadIcon,
-  } from "@mui/icons-material";
-  import { CircularProgress, Stack } from "@mui/material";
-  import React, { useEffect, useState } from "react";
-  import { SmmApi } from "../SmmApi.jsx";
-  import AlertBox from "../components/Common/AlertBox.jsx";
-  import ItemPaginationBar from "../components/Common/ItemPaginationBar";
-  import TabPanel from "../components/Common/TabPanel";
-  import DetailsByLane from "../Heat/DetailsByLane.jsx";
-  import DetailsByHeat from "../Heat/DetailsByHeat.jsx";
-  
-  const EventResults = ({
-    eventName,
-    eventId,
-    onBack,
-    onPrevious,
-    onNext,
-    disablePrevious,
-    disableNext,
-  }) => {
-    const label = "Event " + eventName;
-  
+  ContentPaste as BackIcon,
+  Download as DownloadIcon,
+} from "@mui/icons-material";
+import { CircularProgress, Stack, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { SmmApi } from "../SmmApi.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import ItemPaginationBar from "../components/Common/ItemPaginationBar";
+import MultiSelectWithTags from "../components/Common/MultiSelectWithTags";
+import TabPanel from "../components/Common/TabPanel";
+import GenericTable from "../components/Common/GenericTable.jsx";
+import { formatSeedTime } from "../utils/helperFunctions.js";
+
+const columns = [
+  {
+    accessorKey: "rank",
+    header: "Rank",
+    size: 100,
+  },
+  {
+    accessorKey: "athlete_full_name",
+    header: "Athlete",
+    size: 250,
+  },
+  {
+    accessorKey: "heat_time",
+    header: "Heat time",
+    size: 150,
+    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+  },
+];
+
+const rowHighlight = (row) => {
+  const rank = row.original.rank;
+  if (rank === 1) {
+    return {
+      backgroundColor: "#ffd700",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === 2) {
+    return {
+      backgroundColor: "#c0c0c0",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === 3) {
+    return {
+      backgroundColor: "#DAAA5E",
+      "& *": {
+        color: "#264040",
+        fontWeight: "bold",
+      },
+    };
+  }
+  if (rank === null) {
+    return {
+      backgroundColor: "#f0f0f0",
+      "& *": {
+        color: "#a0a0a0",
+        fontStyle: "italic",
+        fontWeight: "lighter",
+      },
+    };
+  }
+  return {};
+};
+
+const EventResults = ({
+  eventName,
+  eventId,
+  groupId,
+  onBack,
+  onPrevious,
+  onNext,
+  disablePrevious,
+  disableNext,
+}) => {
+  const [resultsData, setResultsData] = useState({});
+  const [count, setCount] = useState(null);
+  const [groupOptions, setGroupOptions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [errorOnLoading, setErrorOnLoading] = useState(false);
+
+  //States MultiSelect
+  const [selectedGroups, setSelectedGroups] = useState([]);
+  const [lastSelectedGroupId, setLastSelectedGroupId] = useState(null);
+
+  //States TabPanel
+  const [tabs, setTabs] = useState([]);
+  const [selectedTab, setSelectedTab] = useState(0);
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetching() {
+      setLoading(true);
+      try {
+        const [resultsResponse, groupFilterResponse] = await Promise.all([
+          SmmApi.getEventResults(eventId),
+          SmmApi.getGroups(groupId),
+        ]);
+        if (!ignore) {
+          setResultsData((prevState) => ({
+            ...prevState,
+            ["main"]: resultsResponse,
+          }));
+          setSelectedGroups([]);
+          setLastSelectedGroupId(null);
+          setSelectedTab(0);
+          setCount(resultsResponse.length);
+          setGroupOptions(groupFilterResponse.data.results);
+          setErrorOnLoading(false);
+          setTabs([
+            {
+              key: "main",
+              label: "General Results",
+              content: (
+                <GenericTable
+                  key={"results"}
+                  data={resultsResponse}
+                  columns={columns}
+                  enableSearch={true}
+                  getRowStyle={rowHighlight}
+                />
+              ),
+            },
+          ]);
+        }
+      } catch (error) {
+        setErrorOnLoading(true);
+      } finally {
+        setTimeout(() => {
+          setLoading(false);
+        }, 100);
+      }
+    }
+    fetching();
+    return () => {
+      ignore = true;
+    };
+  }, [eventId]);
+
+  useEffect(() => {
+    if (lastSelectedGroupId) {
+      const selectedGroup = groupOptions.find(
+        (group) => group.id === lastSelectedGroupId
+      );
+
+      // Check if data for the selected group already exists
+      if (resultsData[lastSelectedGroupId]) {
+        setSelectedTab(tabs.length);
+        setTabs((prevTabs) => [
+          ...prevTabs,
+          {
+            key: lastSelectedGroupId,
+            label: selectedGroup.name,
+            content: (
+              <GenericTable
+                key={lastSelectedGroupId}
+                data={resultsData[lastSelectedGroupId]}
+                columns={columns}
+                enableSearch={true}
+                getRowStyle={rowHighlight}
+              />
+            ),
+            close: true,
+          },
+        ]);
+      } else {
+        const fetchGroupData = async () => {
+          setLoading(true);
+          try {
+            const groupDataResponse = await SmmApi.getEventResults(
+              eventId,
+              lastSelectedGroupId
+            );
+            setResultsData((prevState) => ({
+              ...prevState,
+              [lastSelectedGroupId]: groupDataResponse,
+            }));
+
+            setSelectedTab(tabs.length);
+            setTabs((prevTabs) => [
+              ...prevTabs,
+              {
+                key: lastSelectedGroupId,
+                label: selectedGroup.name,
+                content: (
+                  <GenericTable
+                    key={lastSelectedGroupId}
+                    data={groupDataResponse}
+                    columns={columns}
+                    enableSearch={true}
+                    getRowStyle={rowHighlight}
+                  />
+                ),
+                close: true,
+              },
+            ]);
+          } catch (error) {
+            setSelectedTab(tabs.length);
+            setTabs((prevTabs) => [
+              ...prevTabs,
+              {
+                key: lastSelectedGroupId,
+                label: selectedGroup.name,
+                content: (
+                  <AlertBox type={"error"} message={"Error loading the group results. Please close the tab and try again."}/>
+                ),
+                close: true,
+              },
+            ]);
+          } finally {
+            setLoading(false);
+          }
+        };
+        fetchGroupData();
+      }
+    }
+  }, [lastSelectedGroupId]);
+
+  //What is needed for the itemPaginationBar
+  const label = "Event " + eventName;
+  const extraButtons = [
+    {
+      label: "Back to events",
+      icon: <BackIcon />,
+      onClick: onBack,
+    },
+  ];
+
+  //TabPanel
+
+  const handleRemoveTab = (index) => {
+    const groupId = tabs[index].key;
+    setSelectedGroups((prevGroups) =>
+      prevGroups.filter((group) => group !== groupId)
+    );
+    setTabs((prevTabs) => prevTabs.filter((_, i) => i !== index));
+    setSelectedTab((prevSelected) =>
+      prevSelected === index
+        ? Math.max(0, index - 1)
+        : prevSelected > index
+        ? prevSelected - 1
+        : prevSelected
+    );
+    setLastSelectedGroupId(null);
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <Stack
+          alignItems="center"
+          justifyContent="center"
+          style={{ height: "100px" }}
+        >
+          <CircularProgress />
+        </Stack>
+      );
+    }
+    if (errorOnLoading) {
+      return (
+        <Stack
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            width: "300px",
+            margin: "auto",
+          }}
+        >
+          <AlertBox
+            type="error"
+            message="Unable to load results. Please try again."
+          />
+        </Stack>
+      );
+    }
+
+    if (count > 0) {
+      return (
+        <>
+          <MultiSelectWithTags
+            key={"multi-select"}
+            label={"Filter by group"}
+            options={groupOptions}
+            selectedOptions={selectedGroups}
+            setSelectedOptions={setSelectedGroups}
+            setLastSelected={setLastSelectedGroupId}
+          />
+          <br/>
+          <TabPanel
+            tabs={tabs}
+            selectedTab={selectedTab}
+            setSelectedTab={setSelectedTab}
+            onRemoveTab={handleRemoveTab}
+          />
+        </>
+      );
+    }
+
     return (
-      <div>
-        <ItemPaginationBar
-          label={label}
-          onPrevious={onPrevious}
-          onNext={onNext}
-          disablePrevious={disablePrevious}
-          disableNext={disableNext}
-        ></ItemPaginationBar>
-      </div>
+      <>
+        <Stack
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            width: "300px",
+            margin: "auto",
+          }}
+        >
+          <AlertBox
+            type="success"
+            message={"This event does not have results yet"}
+          />
+        </Stack>
+      </>
     );
   };
-  
-  export default EventResults;
-  
+
+  return (
+    <div>
+      <ItemPaginationBar
+        label={label}
+        onPrevious={onPrevious}
+        onNext={onNext}
+        disablePrevious={disablePrevious}
+        disableNext={disableNext}
+        extraActions={extraButtons}
+      ></ItemPaginationBar>
+      {renderContent()}
+    </div>
+  );
+};
+
+export default EventResults;

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -84,7 +84,6 @@ const EventResults = ({
   disableNext,
 }) => {
   const [resultsData, setResultsData] = useState({});
-  const [count, setCount] = useState(null);
   const [groupOptions, setGroupOptions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
@@ -107,14 +106,10 @@ const EventResults = ({
           SmmApi.getGroups(groupId),
         ]);
         if (!ignore) {
-          setResultsData((prevState) => ({
-            ...prevState,
-            ["main"]: resultsResponse,
-          }));
+          setResultsData({ main: resultsResponse });
           setSelectedGroups([]);
           setLastSelectedGroupId(null);
           setSelectedTab(0);
-          setCount(resultsResponse.length);
           setGroupOptions(groupFilterResponse.data.results);
           setErrorOnLoading(false);
           setTabs([
@@ -212,7 +207,12 @@ const EventResults = ({
                 key: lastSelectedGroupId,
                 label: selectedGroup.name,
                 content: (
-                  <AlertBox type={"error"} message={"Error loading the group results. Please close the tab and try again."}/>
+                  <AlertBox
+                    type={"error"}
+                    message={
+                      "Error loading the group results. Please close the tab and try again."
+                    }
+                  />
                 ),
                 close: true,
               },
@@ -254,6 +254,13 @@ const EventResults = ({
     setLastSelectedGroupId(null);
   };
 
+  const checkEventHasResults = (data) => {
+    if (data.length === 0 || data.some((ele) => ele.heat_time === null)) {
+      return false;
+    }
+    return true;
+  };
+
   const renderContent = () => {
     if (loading) {
       return (
@@ -285,18 +292,23 @@ const EventResults = ({
       );
     }
 
-    if (count > 0) {
+    const hasResults =
+      resultsData.main && checkEventHasResults(resultsData.main);
+
+    if (hasResults) {
       return (
         <>
-          <MultiSelectWithTags
-            key={"multi-select"}
-            label={"Filter by group"}
-            options={groupOptions}
-            selectedOptions={selectedGroups}
-            setSelectedOptions={setSelectedGroups}
-            setLastSelected={setLastSelectedGroupId}
-          />
-          <br/>
+          {groupOptions.length > 0 && (
+            <MultiSelectWithTags
+              key={"multi-select"}
+              label={"Filter by group"}
+              options={groupOptions}
+              selectedOptions={selectedGroups}
+              setSelectedOptions={setSelectedGroups}
+              setLastSelected={setLastSelectedGroupId}
+            />
+          )}
+          <br />
           <TabPanel
             tabs={tabs}
             selectedTab={selectedTab}

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -2,7 +2,7 @@ import {
   ContentPaste as BackIcon,
   Download as DownloadIcon,
 } from "@mui/icons-material";
-import { CircularProgress, Stack, Typography } from "@mui/material";
+import { CircularProgress, Stack } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { SmmApi } from "../SmmApi.jsx";
 import AlertBox from "../components/Common/AlertBox.jsx";
@@ -25,7 +25,7 @@ const columns = [
   },
   {
     accessorKey: "heat_time",
-    header: "Heat time",
+    header: "Heat Time",
     size: 150,
     Cell: ({ cell }) => formatSeedTime(cell.getValue()),
   },
@@ -297,7 +297,7 @@ const EventResults = ({
 
     if (hasResults) {
       return (
-        <>
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
           {groupOptions.length > 0 && (
             <MultiSelectWithTags
               key={"multi-select"}
@@ -308,14 +308,13 @@ const EventResults = ({
               setLastSelected={setLastSelectedGroupId}
             />
           )}
-          <br />
           <TabPanel
             tabs={tabs}
             selectedTab={selectedTab}
             setSelectedTab={setSelectedTab}
             onRemoveTab={handleRemoveTab}
           />
-        </>
+        </div>
       );
     }
 

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -1,0 +1,40 @@
+import {
+    ContentPaste as BackIcon,
+    Build as BuildIcon,
+    Download as DownloadIcon,
+  } from "@mui/icons-material";
+  import { CircularProgress, Stack } from "@mui/material";
+  import React, { useEffect, useState } from "react";
+  import { SmmApi } from "../SmmApi.jsx";
+  import AlertBox from "../components/Common/AlertBox.jsx";
+  import ItemPaginationBar from "../components/Common/ItemPaginationBar";
+  import TabPanel from "../components/Common/TabPanel";
+  import DetailsByLane from "../Heat/DetailsByLane.jsx";
+  import DetailsByHeat from "../Heat/DetailsByHeat.jsx";
+  
+  const EventResults = ({
+    eventName,
+    eventId,
+    onBack,
+    onPrevious,
+    onNext,
+    disablePrevious,
+    disableNext,
+  }) => {
+    const label = "Event " + eventName;
+  
+    return (
+      <div>
+        <ItemPaginationBar
+          label={label}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          disablePrevious={disablePrevious}
+          disableNext={disableNext}
+        ></ItemPaginationBar>
+      </div>
+    );
+  };
+  
+  export default EventResults;
+  

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -10,7 +10,7 @@ import ItemPaginationBar from "../components/Common/ItemPaginationBar";
 import MultiSelectWithTags from "../components/Common/MultiSelectWithTags";
 import TabPanel from "../components/Common/TabPanel";
 import GenericTable from "../components/Common/GenericTable.jsx";
-import { formatSeedTime } from "../utils/helperFunctions.js";
+import { formatTime } from "../utils/helperFunctions.js";
 
 const columns = [
   {
@@ -27,7 +27,7 @@ const columns = [
     accessorKey: "heat_time",
     header: "Heat Time",
     size: 150,
-    Cell: ({ cell }) => formatSeedTime(cell.getValue()),
+    Cell: ({ cell }) => formatTime(cell.getValue()),
   },
 ];
 

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -139,7 +139,6 @@ export class SmmApi {
     if (groupId) {
       url.searchParams.append("filtering_group_id", groupId);
     }
-    console.log(url);
 
     let res = await axios.get(url, {
       headers: getConfig(),

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -134,10 +134,17 @@ export class SmmApi {
     return res.data;
   }
 
-  static async getGroups() {
-    return await axios.get(`${BASE_URL}/group/`, {
+  static async getGroups(groupId=null) {
+    const url = new URL(`${BASE_URL}/group/`);
+    if (groupId) {
+      url.searchParams.append("filtering_group_id", groupId);
+    }
+    console.log(url);
+
+    let res = await axios.get(url, {
       headers: getConfig(),
     });
+    return res;
   }
 
   static async getEventTypes() {

--- a/frontend/src/utils/helperFunctions.js
+++ b/frontend/src/utils/helperFunctions.js
@@ -1,15 +1,33 @@
-export function formatSeedTime(seedTime) {
-  if (!seedTime) return null;
-  if (seedTime === "NT" || seedTime === "DQ" || seedTime === "NS")
-    return seedTime;
-  const timeParts = seedTime.split(":");
-  const secondsAndMillis = parseFloat(timeParts[2]).toFixed(2);
-  if (timeParts[0] !== "00") {
-    return `${timeParts[0]}:${timeParts[1]}:${secondsAndMillis}`;
+export function formatTime(timeStr) {
+  if (!timeStr) return null;
+  if (timeStr === "NT" || timeStr === "DQ" || timeStr === "NS") return timeStr;
+
+  const parts = timeStr.split(":");
+  let formattedTime = [];
+
+  if (parts.length === 3) {
+    // HH:MM:SS.ms
+    const hours = parseInt(parts[0], 10);
+    const minutes = parseInt(parts[1], 10);
+    const [seconds, ms = "00"] = parts[2].split(".");
+
+    if (hours > 0) formattedTime.push(String(hours).padStart(2, "0"));
+    formattedTime.push(String(minutes).padStart(2, "0"));
+    formattedTime.push(
+      `${String(seconds).padStart(2, "0")}.${ms.padEnd(2, "0").slice(0, 2)}`
+    );
+  } else if (parts.length === 2) {
+    // MM:SS.ms
+    const minutes = parseInt(parts[0], 10);
+    const [seconds, ms = "00"] = parts[1].split(".");
+
+    if (minutes > 0) formattedTime.push(String(minutes).padStart(2, "0"));
+    formattedTime.push(
+      `${String(seconds).padStart(2, "0")}.${ms.padEnd(2, "0").slice(0, 2)}`
+    );
+  } else {
+    throw new Error("Invalid time format");
   }
-  if (timeParts[1] !== "00") {
-    const minutes = parseInt(timeParts[1], 10);
-    return `${minutes}:${secondsAndMillis}`;
-  }
-  return `${secondsAndMillis}`;
+
+  return formattedTime.join(":");
 }


### PR DESCRIPTION
This PR addresses issue #170 

### Implementation

1. New component: `EventResults`

- Functionality:
  - Displays an `ItemPaginationBar` to navigate through all events in the swim meet.
  - If an event has no results, it renders an `AlertBox` to inform the user.
  - If results are available:
    -  Renders a `MultiSelectWithTags` dropdown containing all the groups that could have results for the event.
    -  Displays a `TabPanel` showing general results for the event.
  - Selecting a group from the MultiSelectWithTags:
    - Adds a new tab to the `TabPanel` displaying results for the selected group.
    - Disables the group in the dropdown to prevent re-selection.
  -  Closing a tab re-enables the corresponding group in the `MultiSelectWithTags`.

- Result Highlighting:
  - 1st, 2nd, and 3rd place: Highlighted in gold, silver, and bronze respectively.
  - NS (No Show) and DQ (Disqualified): Highlighted with gray tones.


2. File Modifications:

-  **backend/api/views/GroupView.py**
   -  Removed an unnecessary `print` statement.

- **frontend/src/Event/MeetEventDisplay.jsx**
  - Added a new case (results) in the renderContent function.
  - When the `Ranking` action is clicked, the view state is updated to results, and the `EventResults` component is rendered.
  
- **frontend/src/SmmApi.jsx**
  - Updated the `getGroups` method to include an **extra_parameter** named `filtering_group_id`.

### UI Preview

- Initial view when an event has results:

![image](https://github.com/user-attachments/assets/46b47448-78a0-4ce2-999e-a1105bfc5851)

-  Added a new tab by selecting a group from the Filter by group dropdown.

![image](https://github.com/user-attachments/assets/90388efa-8c3a-428f-85e7-a41ae5037991)

- AlertBox displayed when an event does not have all the results submitted (or does not have heats).

![image](https://github.com/user-attachments/assets/7a8726b4-0a7e-4484-ac9b-49ca96b42775)

- When the filter by group dropdown its empty it is not rendered.
![image](https://github.com/user-attachments/assets/83fd8a66-1daf-4d83-b04f-5600f96ed1fb)
