### PR TITLE
BE- Endpoint  to generate xlsx file with event results

### DIFF
--- a/backend/api/serializers/GroupSerializer.py
+++ b/backend/api/serializers/GroupSerializer.py
@@ -60,8 +60,8 @@ class GroupsListSerializer(serializers.Serializer):
 
     def validate_group_ids(self, value):
         # Check if all group_ids exist
-        existing_school_ids = Group.objects.values_list('id', flat=True)
-        invalid_ids = set(value) - set(existing_school_ids)
+        existing_groups_ids = Group.objects.values_list('id', flat=True)
+        invalid_ids = set(value) - set(existing_groups_ids)
 
         if invalid_ids:
             raise serializers.ValidationError(

--- a/backend/api/serializers/GroupSerializer.py
+++ b/backend/api/serializers/GroupSerializer.py
@@ -24,16 +24,18 @@ class GroupSerializer(serializers.ModelSerializer):
         min_age = data.get('min_age', None)
         max_age = data.get('max_age', None)
         if min_age is not None and min_age <= 0:
-            raise serializers.ValidationError({'min_age': "Min age must be greater than 0."})
+            raise serializers.ValidationError(
+                {'min_age': "Min age must be greater than 0."})
 
         if max_age is not None and max_age <= 0:
-            raise serializers.ValidationError({'max_age': "Max age must be greater than 0."})
+            raise serializers.ValidationError(
+                {'max_age': "Max age must be greater than 0."})
 
         if min_age is not None and max_age is not None and min_age > max_age:
             raise serializers.ValidationError({
-                    'min_age': "Min age must be less than or equal to max age.",
-                    'max_age': "Max age must be greater than or equal to min age."
-                })
+                'min_age': "Min age must be less than or equal to max age.",
+                'max_age': "Max age must be greater than or equal to min age."
+            })
         return data
 
     def validate_unique_group(self, data):
@@ -47,5 +49,22 @@ class GroupSerializer(serializers.ModelSerializer):
             max_age=max_age,
             gender=gender
         ).exists():
-            raise serializers.ValidationError("A group with this caracteristics already exists.")
+            raise serializers.ValidationError(
+                "A group with this caracteristics already exists.")
         return data
+
+
+class GroupsListSerializer(serializers.Serializer):
+    group_ids = serializers.ListField(
+        child=serializers.IntegerField(), allow_empty=True)
+
+    def validate_group_ids(self, value):
+        # Check if all group_ids exist
+        existing_school_ids = Group.objects.values_list('id', flat=True)
+        invalid_ids = set(value) - set(existing_school_ids)
+
+        if invalid_ids:
+            raise serializers.ValidationError(
+                f"Invalid group IDs: {list(invalid_ids)}")
+
+        return value

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -17,6 +17,7 @@ from api.views.HeatView import HeatBatchView, HeatDetailView
 from api.views.LaneView import LaneBatchView, LaneDetailView, UpdateHeatTimeView
 from api.views.EventResultView import EventResultView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
+from api.views.download.DownloadResults import DownloadEventResults
 
 from rest_framework.routers import SimpleRouter
 
@@ -55,6 +56,8 @@ urlpatterns = [
          DownloadAllHeatsByEvent.as_view(), name='download-event-heats-details'),
     path('download-all-heats-details/<int:meet_id>/',
          DownloadAllHeatsByMeet.as_view(), name='download-meet-heats-details'),
+    path('download-event-results/<int:event_id>/',
+         DownloadEventResults.as_view(), name='download-event-results'),
     path('event_lane/update_heat_times/',
          UpdateHeatTimeView.as_view(), name='update-heat-time')
 ]

--- a/backend/api/utils/HelperFunctions.py
+++ b/backend/api/utils/HelperFunctions.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+
+def format_time(time):
+    if not time:
+        return None
+    if time == timedelta(days=200):
+        return "NT"
+    elif time == timedelta(days=300):
+        return "NS"
+    elif time == timedelta(days=400):
+        return "DQ"
+
+    parts = str(time).split(":")
+    formatted_time = []
+
+    if len(parts) == 3:
+        # HH:MM:SS.ms
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        seconds, ms = (parts[2].split(".") + ["00"])[:2]
+
+        if hours > 0:
+            formatted_time.append(str(hours).zfill(2))
+        formatted_time.append(str(minutes).zfill(2))
+        formatted_time.append(
+            f"{str(seconds).zfill(2)}.{ms.ljust(2, '0')[:2]}")
+
+    elif len(parts) == 2:
+        # MM:SS.ms
+        minutes = int(parts[0])
+        seconds, ms = (parts[1].split(".") + ["00"])[:2]
+
+        if minutes > 0:
+            formatted_time.append(str(minutes).zfill(2))
+        formatted_time.append(
+            f"{str(seconds).zfill(2)}.{ms.ljust(2, '0')[:2]}")
+
+    else:
+        raise ValueError("Invalid time format")
+
+    return ":".join(formatted_time)

--- a/backend/api/views/download/DownloadHeats.py
+++ b/backend/api/views/download/DownloadHeats.py
@@ -7,6 +7,7 @@ from openpyxl.utils import get_column_letter
 from openpyxl.styles import Alignment
 from rest_framework.views import APIView
 from datetime import timedelta
+from api.utils.HelperFunctions import format_time
 
 
 def create_excel_file_for_heats_details(swim_meet_details, event_data):
@@ -155,29 +156,6 @@ def create_excel_file_for_heats_details(swim_meet_details, event_data):
     file_buffer.seek(0)
 
     return file_buffer
-
-
-def format_time(time):
-    if not time:
-        return None
-    if time == timedelta(days=200):
-        return "NT"
-    elif time == timedelta(days=300):
-        return "NS"
-    elif time == timedelta(days=400):
-        return "DQ"
-
-    time_parts = str(time).split(":")
-    seconds_and_millis = f"{float(time_parts[2]):.2f}"
-
-    if time_parts[0] != "0":
-        return f"{time_parts[0]}:{time_parts[1]}:{seconds_and_millis}"
-
-    if time_parts[1] != "00":
-        minutes = int(time_parts[1])
-        return f"{minutes}:{seconds_and_millis}"
-
-    return seconds_and_millis
 
 
 @extend_schema(tags=['Download'])

--- a/backend/api/views/download/DownloadResults.py
+++ b/backend/api/views/download/DownloadResults.py
@@ -1,0 +1,192 @@
+from datetime import timedelta
+from io import BytesIO
+from api.CustomFilter import filter_by_group
+from api.models import Group, Heat, MeetEvent
+from api.serializers.GroupSerializer import GroupsListSerializer
+from api.utils.HelperFunctions import format_time
+from django.http import HttpResponse
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, PatternFill
+from openpyxl.utils import get_column_letter
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+def create_excel_file_for_event_results(swim_meet_details, event_name, results_by_group):
+    workbook = Workbook()
+
+    # Colors for ranks
+    gold_fill = PatternFill(start_color="FFD700",
+                            end_color="FFD700", fill_type="solid")
+    silver_fill = PatternFill(start_color="C0C0C0",
+                              end_color="C0C0C0", fill_type="solid")
+    bronze_fill = PatternFill(start_color="CD7F32",
+                              end_color="CD7F32", fill_type="solid")
+
+    is_first_sheet = True
+    for group_name, group_results in results_by_group.items():
+        if is_first_sheet:
+            results_worksheet = workbook.active
+            results_worksheet.title = group_name
+            is_first_sheet = False
+        else:
+            results_worksheet = workbook.create_sheet(title=group_name)
+
+        results_headers = ["Rank", "Athlete", "Heat Time"]
+        current_row = 1
+
+        # Swim Meet Information
+        results_worksheet.merge_cells(
+            start_row=1, start_column=1, end_row=1, end_column=len(results_headers))
+        swim_meet_cell = results_worksheet.cell(row=1, column=1)
+        swim_meet_cell.value = f"{swim_meet_details['name']}\n{swim_meet_details['date']}\n{swim_meet_details['location']}\n"
+        swim_meet_cell.style = 'Title'
+        swim_meet_cell.alignment = Alignment(
+            horizontal="center", vertical="center", wrap_text=True)
+
+        current_row += 2
+
+        # Event RESULTS
+        results_worksheet.merge_cells(
+            start_row=current_row, start_column=1, end_row=current_row, end_column=len(results_headers))
+        event_meet_cell = results_worksheet.cell(row=current_row, column=1)
+        event_meet_cell.value = f"{event_name}\n RESULTS"
+        event_meet_cell.style = 'Headline 1'
+        event_meet_cell.alignment = Alignment(
+            horizontal="center", vertical="center", wrap_text=True)
+        current_row += 3
+
+        # Title
+        results_worksheet.merge_cells(
+            start_row=current_row, start_column=1, end_row=current_row, end_column=len(results_headers)
+        )
+        group_cell = results_worksheet.cell(row=current_row, column=1)
+        group_cell.value = f"{group_name}"
+        group_cell.alignment = Alignment(
+            horizontal="center", vertical="center", wrap_text=True)
+        group_cell.style = 'Headline 1'
+
+        current_row += 2
+
+        # Headers
+        for col_num, header in enumerate(results_headers, start=1):
+            header_cell = results_worksheet.cell(
+                row=current_row, column=col_num)
+            header_cell.value = header
+            header_cell.style = 'Headline 3'
+        current_row += 1
+
+        # Data
+        for result in group_results:
+            rank_cell = results_worksheet.cell(
+                row=current_row, column=1, value=result.rank)
+            athlete_cell = results_worksheet.cell(
+                row=current_row, column=2, value=f"{result.athlete.first_name} {result.athlete.last_name}"
+            )
+            heat_time_cell = results_worksheet.cell(row=current_row, column=3,
+                                                    value=format_time(result.heat_time))
+
+            if result.rank == 1:
+                rank_cell.fill = gold_fill
+                athlete_cell.fill = gold_fill
+                heat_time_cell.fill = gold_fill
+            elif result.rank == 2:
+                rank_cell.fill = silver_fill
+                athlete_cell.fill = silver_fill
+                heat_time_cell.fill = silver_fill
+            elif result.rank == 3:
+                rank_cell.fill = bronze_fill
+                athlete_cell.fill = bronze_fill
+                heat_time_cell.fill = bronze_fill
+
+            current_row += 1
+
+        # Adjust column widths
+        for col_num in range(1, len(results_headers) + 1):
+            col_letter = get_column_letter(col_num)
+            results_worksheet.column_dimensions[col_letter].width = 20
+
+    # Save workbook to an in-memory file
+    file_buffer = BytesIO()
+    workbook.save(file_buffer)
+    file_buffer.seek(0)
+    return file_buffer
+
+
+@extend_schema(tags=['Download'], request=GroupListSerializer,)
+class DownloadEventResults(APIView):
+
+    @extend_schema(
+
+        summary='Send Binary response with the contents of a xlsx file with the event results',
+        responses={
+            200: OpenApiResponse(description='Binary Response for xlsx file created'),
+            404: OpenApiResponse(description='Resource not found')
+        }
+    )
+    def post(self, request, event_id):
+
+        # Get event instance
+        event_instance = MeetEvent.objects.get(id=event_id)
+
+        swim_meet_instance = event_instance.swim_meet
+
+        swim_meet_details = {
+            'name': swim_meet_instance.name,
+            'date': swim_meet_instance.date.strftime('%m/%d/%Y'),
+            'location': swim_meet_instance.site.name
+        }
+
+        general_results = self.get_queryset(event_instance)
+
+        serializer = GroupsListSerializer(data=request.data)
+        if serializer.is_valid():
+            group_ids = serializer.validated_data['group_ids']
+            if not group_ids:
+                group_ids = []
+            print(group_ids)
+            results_by_group = {"General Results": general_results}
+            for group_id in group_ids:
+                group_results = self.get_queryset(event_instance, group_id)
+                if group_results:
+                    group_instance = Group.objects.get(id=group_id)
+                    group_name = group_instance.name
+                    results_by_group[group_name] = group_results
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # Generate Excel file
+        file = create_excel_file_for_event_results(swim_meet_details,
+                                                   event_instance.name, results_by_group)
+        file_name = f"{event_instance.name}_Results.xlsx"
+
+        # Create HTTP response
+        response = HttpResponse(
+            file,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        response["Content-Disposition"] = f'attachment; filename="{file_name}"'
+        return response
+
+    def get_queryset(self, event_instance, group_id=None):
+        queryset = Heat.objects.filter(event=event_instance)
+        if group_id is not None:
+            queryset = filter_by_group(group_id, queryset, False)
+
+        results = list(queryset.order_by(
+            'heat_time', 'athlete__last_name', 'athlete__first_name'))
+        if results:
+            current_rank = 1
+            previous_time = -1
+            for i, result in enumerate(results):
+                if result.heat_time in [timedelta(days=300), timedelta(days=400), None]:
+                    result.rank = ""
+                elif result.heat_time == previous_time:
+                    result.rank = current_rank
+                else:
+                    current_rank = i + 1
+                    result.rank = current_rank
+                previous_time = result.heat_time
+        return results

--- a/backend/api/views/download/DownloadResults.py
+++ b/backend/api/views/download/DownloadResults.py
@@ -115,7 +115,7 @@ def create_excel_file_for_event_results(swim_meet_details, event_name, results_b
     return file_buffer
 
 
-@extend_schema(tags=['Download'], request=GroupListSerializer,)
+@extend_schema(tags=['Download'], request=GroupsListSerializer,)
 class DownloadEventResults(APIView):
 
     @extend_schema(


### PR DESCRIPTION
This PR address issue #192  .

### Implementation
   - **backend/api/serializers/GroupSerializer.py**
Add `GroupsListSerializer` which defines  group_ids as a ListField in order to accept a List of group_ids (int).

   - **backend/api/views/download/DownloadResults.py**
Add new class view (`DownloadEventResults`).
This view includes a `post` method to get the information related to the provided `event_id` heats results. It retrieves all the Heat records for the event and assign a ranking to each athlete.
A list of group_ids can be passed, in that case, the Heat records are filtered to get only the ones associated with the athletes in the given group. 
It calls the method `create_excel_file_for_event_results` to generate an excel file with these information and return it as a response.


   - **backend/api/urls.py**
A new path was defined to call the `post` method in `DownloadAllHeatsByMeet` view:
`download-event-results/<int:event_id>/
`
   - **backend/api/utils/HelperFunctions.py**
Add helper function to format a  time to string with format MM:SS.ms
  
 - **backend/api/views/download/DownloadHeats.py**
Remove local format time function and use new helper function to format time

### Swagger
The endpoint `/api/download-event-results/{event_id}/` is listed in the Download section:
<img width="1188" alt="Screenshot 2024-12-05 at 10 14 58 PM" src="https://github.com/user-attachments/assets/673de8dd-75f2-4984-977a-812c98246e7c">

Try the endpoint with event_id = 1. The response is a link to download the xlsx file:

<img width="1079" alt="Screenshot 2024-12-05 at 10 18 13 PM" src="https://github.com/user-attachments/assets/f692f354-b5f6-4906-afa8-f3841d7548c6">


After downloading the file, it can be imported to google sheets. This is a view for the General Results spreadsheet (

<img width="560" alt="Screenshot 2024-12-05 at 10 20 21 PM" src="https://github.com/user-attachments/assets/462e2f14-b8fe-49bf-b95e-8d3f9d500a72">

Try the endpoint with event_id = 1 and a list of group_ids 4 and 5. The response is a link to download the xlsx file:

<img width="703" alt="Screenshot 2024-12-05 at 10 21 18 PM" src="https://github.com/user-attachments/assets/20031336-1e94-4175-a6fb-ce9e31454cf1">



After downloading the file, it can be imported to google sheets. Following are the views for the General Results, Girls11&Above (group_id 4) and Girls10&Under(group_id 5)   spreadsheets

<img width="639" alt="Screenshot 2024-12-05 at 10 22 38 PM" src="https://github.com/user-attachments/assets/9816585e-e2f2-4e6e-8edc-81f7a95517b6">
<img width="629" alt="Screenshot 2024-12-05 at 10 22 53 PM" src="https://github.com/user-attachments/assets/070e3b5a-30d1-4f35-8ed4-6f46049be4d0">

<img width="621" alt="Screenshot 2024-12-05 at 10 22 46 PM" src="https://github.com/user-attachments/assets/a482a179-f631-44fc-ae23-3119fd132de2">


