### PR TITLE
FE - Download Event Results in a xlsx File

### DIFF
--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -137,7 +137,6 @@ const MeetEventDisplay = () => {
       tip: "Go to ranking",
       visible: (row) => row.original.total_num_heats > 0,
     },
-    
   ];
 
   useEffect(() => {
@@ -305,6 +304,7 @@ const MeetEventDisplay = () => {
       case "results":
         return (
           <EventResults
+            swimMeetName={meetData.name}
             eventName={currentEvent.name}
             eventId={currentEvent.id}
             groupId={currentEvent.group}

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -84,7 +84,7 @@ const EventResults = ({
   disablePrevious,
   disableNext,
 }) => {
-  const [resultsData, setResultsData] = useState({});
+  const [resultsData, setResultsData] = useState({ main: [] });
   const [groupOptions, setGroupOptions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
@@ -253,7 +253,9 @@ const EventResults = ({
   };
 
   const handleDownloadResultsForEvent = async () => {
-    const payload = { group_ids: selectedGroups };
+    const payload = {
+      group_ids: selectedGroups.filter((id) => id !== "placeholder"),
+    };
     try {
       await SmmApi.downloadResultsForEvent(
         swimMeetName,
@@ -279,7 +281,7 @@ const EventResults = ({
       label: "Download Results",
       icon: <DownloadIcon />,
       onClick: handleDownloadResultsForEvent,
-      disabled: !resultsData.main || resultsData.main.length === 0,
+      disabled: !checkEventHasResults(resultsData.main),
     },
   ];
 

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -74,6 +74,7 @@ const rowHighlight = (row) => {
 };
 
 const EventResults = ({
+  swimMeetName,
   eventName,
   eventId,
   groupId,
@@ -251,7 +252,20 @@ const EventResults = ({
     return true;
   };
 
-  const handleDownloadResultsForEvent = async () => {};
+  const handleDownloadResultsForEvent = async () => {
+    const payload = { group_ids: selectedGroups };
+    try {
+      await SmmApi.downloadResultsForEvent(
+        swimMeetName,
+        eventName,
+        eventId,
+        payload
+      );
+    } catch (error) {
+      console.error("Download failed:", error);
+      alert("There was an error downloading the file. Please try again.");
+    }
+  };
 
   //What is needed for the itemPaginationBar
   const label = "Event " + eventName;

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -226,16 +226,6 @@ const EventResults = ({
     }
   }, [lastSelectedGroupId]);
 
-  //What is needed for the itemPaginationBar
-  const label = "Event " + eventName;
-  const extraButtons = [
-    {
-      label: "Back to events",
-      icon: <BackIcon />,
-      onClick: onBack,
-    },
-  ];
-
   //TabPanel
 
   const handleRemoveTab = (index) => {
@@ -260,6 +250,24 @@ const EventResults = ({
     }
     return true;
   };
+
+  const handleDownloadResultsForEvent = async () => {};
+
+  //What is needed for the itemPaginationBar
+  const label = "Event " + eventName;
+  const extraButtons = [
+    {
+      label: "Back to events",
+      icon: <BackIcon />,
+      onClick: onBack,
+    },
+    {
+      label: "Download Results",
+      icon: <DownloadIcon />,
+      onClick: handleDownloadResultsForEvent,
+      disabled: !resultsData.main || resultsData.main.length === 0,
+    },
+  ];
 
   const renderContent = () => {
     if (loading) {

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -291,11 +291,11 @@ export class SmmApi {
     return res.data;
   }
 
-  static async downloadResultsForEvent(swimMeetName, eventName, eventId) {
+  static async downloadResultsForEvent(swimMeetName, eventName, eventId, data) {
     try {
       const response = await axios.post(
         `${BASE_URL}/download-event-results/${eventId}/`,
-        {},
+        data,
         {
           headers: getConfig(),
           responseType: "blob", // Important for file downloads

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -134,7 +134,7 @@ export class SmmApi {
     return res.data;
   }
 
-  static async getGroups(groupId=null) {
+  static async getGroups(groupId = null) {
     const url = new URL(`${BASE_URL}/group/`);
     if (groupId) {
       url.searchParams.append("filtering_group_id", groupId);
@@ -269,8 +269,6 @@ export class SmmApi {
     }
   }
 
-
-
   static async registerHeatTimes(data) {
     return await axios.put(`${BASE_URL}/event_lane/update_heat_times/`, data, {
       headers: getConfig(),
@@ -292,5 +290,37 @@ export class SmmApi {
     });
     return res.data;
   }
-    
+
+  static async downloadResultsForEvent(swimMeetName, eventName, eventId) {
+    try {
+      const response = await axios.post(
+        `${BASE_URL}/download-event-results/${eventId}/`,
+        {},
+        {
+          headers: getConfig(),
+          responseType: "blob", // Important for file downloads
+        }
+      );
+
+      // Create a URL for the blob and trigger the download
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+
+      // Set the file name
+      link.setAttribute(
+        "download",
+        `Results_${swimMeetName}_${eventName}.xlsx`
+      );
+
+      document.body.appendChild(link);
+      link.click();
+
+      // Cleanup
+      link.parentNode.removeChild(link);
+    } catch (error) {
+      console.error("Error downloading heats file:", error);
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
This PR address issue #194 .

### Implementation

   - **frontend/src/SmmApi.jsx**
the following `downloadResultsForEvent(swimMeetName, eventName, eventId, data)` was  added. Sends a POST request to generate a file with all the results for a specified event (eventId).

   - **frontend/src/Event/MeetEventDisplay.jsx**
      -  Add swimMeetName as a prop for EventResults component.
      
   - **frontend/src/Results/EventResults.jsx**
      - Add Download Results button in the ItemPaginationBar. It is disable if the event has no results (i.e. not all the heat times are registered).
      - The handleDownloadResultsForEvent implements the logic to call the API to download the results.
      - The swimMeetName prop is added to pass it to the API call to include the name of the swim meet in the file name.

### UI

The Download Results button is display for the event with results:
<img width="1715" alt="Screenshot 2024-12-06 at 1 40 23 PM" src="https://github.com/user-attachments/assets/e70a1c93-614e-465d-b6e7-c8b4fb260528">

The Download Details button is disable for the event with no results:
<img width="1347" alt="Screenshot 2024-12-06 at 1 41 24 PM" src="https://github.com/user-attachments/assets/5a807cef-2389-48f4-a290-06d0ad08bd5b">




