### PR TITLE
BE-Custom filter filter_by_group applied to code

### DIFF
--- a/backend/api/views/AthleteSeedTimeView.py
+++ b/backend/api/views/AthleteSeedTimeView.py
@@ -1,10 +1,9 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from api.models import Athlete, TimeRecord, MeetEvent, Group, EventType
+from api.models import Athlete, TimeRecord, MeetEvent, EventType
 from api.serializers.AthleteSeedTimeSerializer import AthleteSeedTimeSerializer, UpdateAthleteSeedTimeSerializer
 from api.CustomFilter import filter_by_group
-from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 from datetime import timedelta

--- a/backend/api/views/AthleteView.py
+++ b/backend/api/views/AthleteView.py
@@ -8,6 +8,7 @@ from api.models import Athlete, Group
 from api.serializers.AthleteSerializer import AthleteSerializer
 from django.db.models import F, Func, IntegerField, Value
 from django.utils import timezone
+from api.CustomFilter import filter_by_group
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 import logging
 
@@ -36,21 +37,7 @@ class AthleteViewSet(viewsets.ModelViewSet):
         )
         group_id = self.request.query_params.get('group_id')
         if group_id is not None:
-            try:
-                group_instance = Group.objects.get(id=group_id)
-            except:
-                raise ValidationError({'error': "Group does not exist"}, code=status.HTTP_400_BAD_REQUEST)
-            gender = group_instance.gender
-            print(gender)
-            if gender!='MX':
-                queryset = queryset.filter(gender=gender)
-            min_age = group_instance.min_age
-            max_age = group_instance.max_age
-            print(min_age,max_age)
-            if max_age is not None:
-                queryset = queryset.filter(age__lte=max_age)
-            if min_age is not None:
-                queryset = queryset.filter(age__gte=min_age)
+            queryset = filter_by_group(group_id=group_id, queryset=queryset)
         return queryset
     
     @extend_schema(parameters =[OpenApiParameter(name="group_id", type=int),])

--- a/backend/api/views/AthleteView.py
+++ b/backend/api/views/AthleteView.py
@@ -1,10 +1,8 @@
 from rest_framework import viewsets
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.exceptions import ValidationError
-from rest_framework import status
 from django.db.models.functions import Collate
-from api.models import Athlete, Group
+from api.models import Athlete
 from api.serializers.AthleteSerializer import AthleteSerializer
 from django.db.models import F, Func, IntegerField, Value
 from django.utils import timezone

--- a/backend/api/views/EventResultView.py
+++ b/backend/api/views/EventResultView.py
@@ -28,7 +28,7 @@ class EventResultView(APIView):
         queryset = Heat.objects.filter(event=event_instance)
         group_id = self.request.query_params.get('group_id')
         if group_id is not None:
-            queryset = filter_by_group(group_id, queryset, False)
+            queryset = filter_by_group(group_id=group_id, queryset=queryset, date=event_instance.swim_meet.date, from_athlete_model=False)
 
         results = list(queryset.order_by('heat_time', 'athlete__last_name', 'athlete__first_name'))
         

--- a/backend/api/views/TimeRecordView.py
+++ b/backend/api/views/TimeRecordView.py
@@ -1,14 +1,13 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
-from api.models import TimeRecord, EventType, Group
+from api.models import TimeRecord, EventType
 from api.serializers.TimeRecordSerializer import TimeRecordSerializer
 from drf_spectacular.utils import extend_schema, OpenApiParameter
-from django.db.models import Q, F, Value, Func, IntegerField
+from django.db.models import Q, F, Value
 from django.db.models.functions import Collate, Concat
 from rest_framework.exceptions import ValidationError
 from rest_framework import status
 from api.CustomFilter import filter_by_group
-from django.utils import timezone
 
 import logging
 


### PR DESCRIPTION
This PR address issue #168 

### Implementation

1.Enhancements to `filter_by_group`:

-  Keyword-only arguments:
   - Updated the function to require all arguments to be passed as keyword arguments. This improves readability and ensures that parameters can be provided in any order as long as they are named.
- Added `date` parameter:
  - Introduced an optional `date` parameter to allow filtering by age as of a specific date. Defaults to the current date (`timezone.now().date()`) if not provided.
- Renamed `athlete` parameter to `for_athlete_model`:
   - This new name better reflects the purpose of the parameter, as it indicates whether the filtering applies directly to the `Athlete` model or to a related model with a foreign key to `Athlete`.
- Group validation:
   - Ensures that the function validates the existence of the group specified by `group_id` and raises a `ValidationError` if the group does not exist.


2. Integration of `filter_by_group`:

- **backend/api/views/AthleteSeedTimeView.py**
   - Now uses f`ilter_by_group`, passing the date of the swim meet for accurate age-based filtering.
-  **backend/api/views/AthleteView.py**
   - Uses `filter_by_group` with the current date to display athletes accurately based on their age today.
-  **backend/api/views/EventResultView.py**
   - Previously used the filter without specifying a date. Updated to pass the swim meet's date for consistency.
-   **backend/api/views/TimeRecordView.py**
    - Uses filter_by_group with the current date for age-based filtering.

### Testing

- Updated fixture files locally to include two swim meets: one before today and one after.
- Adjusted an athlete’s (Luis Martinez) date of birth such that:
  - `Today`: Luis is 10 years old.
  - `On the second swim meet date`: Luis is 11 years old.
 
### Results

- `Athlete table today`: Luis Martinez appears with age 10.

![image](https://github.com/user-attachments/assets/976023ad-9ad4-408d-a0e8-f216448605a3)

- First swim meet (for Boys 11 & Above): Luis does not appear as an available athlete because his age is 10 on the meet date.

![image](https://github.com/user-attachments/assets/52e3e0cb-f505-4270-a018-0b471ab66226)


- Second swim meet (for Boys 11 & Above): Luis appears as an available athlete because his age is 11 on the meet date.

![image](https://github.com/user-attachments/assets/f76b1f9e-d06e-4548-aaee-3a0523cd2e47)
