### PR TITLE
FE - Update Athlete Table

### DIFF
--- a/backend/api/serializers/AthleteSerializer.py
+++ b/backend/api/serializers/AthleteSerializer.py
@@ -8,12 +8,13 @@ class AthleteSerializer(serializers.ModelSerializer):
     last_name = serializers.CharField(max_length=50)
     full_name = serializers.CharField(read_only=True)
     age = serializers.IntegerField(read_only=True)
+    gender_display = serializers.CharField(source='get_gender_display', read_only=True)
 
 
     class Meta:
         model = Athlete
         fields = '__all__'
-        read_only_fields = ['full_name', 'age']
+        read_only_fields = ['full_name', 'age','gender_display']
 
     # Validate that the date is not in the future
     def validate_date_of_birth(self, value):

--- a/frontend/src/Athlete/AthleteDisplay.jsx
+++ b/frontend/src/Athlete/AthleteDisplay.jsx
@@ -21,6 +21,11 @@ const columns = [
     size: 150,
   },
   {
+    accessorKey: "gender_display",
+    header: "Gender",
+    size: 150,
+  },
+  {
     accessorKey: "age",
     header: "Age",
     size: 150,
@@ -78,17 +83,17 @@ const AthleteDisplay = () => {
     lastCreatedAthleteId.current = null;
   };
 
-/*   const handleEditClick = () => {
+  const handleEditClick = () => {
     console.log("Edit ...");
-  };*/
+  };
 
   const actions = [
-/*     {
+    {
       name: "Edit",
       icon: <EditIcon />,
       onClick: handleEditClick,
       tip: "Edit basic information",
-    }, */
+    },
   ]; 
 
   useEffect(() => {

--- a/frontend/src/Athlete/AthleteDisplay.jsx
+++ b/frontend/src/Athlete/AthleteDisplay.jsx
@@ -92,7 +92,7 @@ const AthleteDisplay = () => {
       name: "Edit",
       icon: <EditIcon />,
       onClick: handleEditClick,
-      tip: "Edit basic information",
+      tip: "Edit Athlete",
     },
   ]; 
 


### PR DESCRIPTION
This PR address issue #205 

### Implementation

1. **backend/api/serializers/AthleteSerializer.py**
- Added a `gender_display` field as read-only to the serializer. This field returns the human-readable label (e.g., "Girl" or "Boy") for each gender option.

2. **frontend/src/Athlete/AthleteDisplay.jsx**

- Added a new column to the columns configuration with the header "Gender." This column displays the `gender_display` value from the API.
- Added an "Edit" action to the actions array. For now, this action logs "Edit..." to the console.

UI Preview

- The "Gender" column now displays the human-readable gender value in the Athlete table:
![image](https://github.com/user-attachments/assets/d485f467-45ef-4156-8571-4413e07a5fc3)

