### PR TITLE
BE-Ordering Groups, Sites, EventTypes

### DIFF
--- a/backend/api/views/EventTypeView.py
+++ b/backend/api/views/EventTypeView.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.filters import OrderingFilter
 from api.models import EventType
 from api.serializers.EventTypeSerializer import EventTypeSerializer
 from drf_spectacular.utils import extend_schema
@@ -13,4 +14,6 @@ class EventTypeViewSet(viewsets.ModelViewSet):
     queryset = EventType.objects.all()
     serializer_class = EventTypeSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [OrderingFilter]
     http_method_names = ['get', 'post', 'patch', 'delete']
+    ordering = ['type', 'distance', 'stroke']

--- a/backend/api/views/GroupView.py
+++ b/backend/api/views/GroupView.py
@@ -3,9 +3,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import NotFound
 from api.models import Group
 from api.serializers.GroupSerializer import GroupSerializer
+from rest_framework.filters import OrderingFilter
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
-from django.db.models import Q
+from django.db.models import Q, Case, When, Value, F, CharField, IntegerField
+from django.db.models.functions import Concat
 import logging
 
 logger = logging.getLogger('django')
@@ -27,14 +29,42 @@ class GroupViewSet(viewsets.ModelViewSet):
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [OrderingFilter]
     http_method_names = ['get', 'post', 'patch', 'delete']
 
     def get_queryset(self):
         queryset = super().get_queryset()
+        queryset = queryset.annotate(
+            gender_display=Case(
+                When(gender="F", then=Value("Girls")),
+                When(gender="M", then=Value("Boys")),
+                When(gender="MX", then=Value("Mixed")),
+                output_field=CharField(),
+            ),
+            age_range=Case(
+                When(min_age__isnull=False, max_age__isnull=False, min_age=F('max_age'), then=Concat(F('min_age'), Value(""))),
+                When(min_age__isnull=False, max_age__isnull=False, then=Concat(F('min_age'), Value("to"), F('max_age'))),
+                When(min_age__isnull=False, max_age__isnull=True, then=Concat(F('min_age'), Value("&Above"))),
+                When(min_age__isnull=True, max_age__isnull=False, then=Concat(F('max_age'), Value("&Under"))),
+                default=Value(""),
+                output_field=CharField(),
+            ),
+            generated_name=Concat(
+                F('gender_display'),
+                F('age_range'),
+                output_field=CharField(),
+            ),
+            gender_priority=Case(
+                When(gender="MX", then=Value(0)), 
+                When(gender="F", then=Value(1)),
+                When(gender="M", then=Value(2)),  
+                output_field=IntegerField(),
+            )
+        )
 
         filtering_group_id = self.request.query_params.get('filtering_group_id', None)
         if not filtering_group_id:
-            return queryset
+            return queryset.order_by('gender_priority','generated_name')
 
         try:
             filtering_group = Group.objects.get(id=filtering_group_id)
@@ -52,4 +82,4 @@ class GroupViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(Q(min_age__gte=filter_min_age) | Q(max_age__gte=filter_min_age))
         elif filter_max_age and filter_min_age is None:
             queryset = queryset.filter(Q(max_age__lte=filter_max_age) | Q(min_age__lte=filter_max_age))
-        return queryset.exclude(id=filtering_group.id)
+        return queryset.exclude(id=filtering_group.id).order_by('gender_priority','generated_name')

--- a/backend/api/views/SiteView.py
+++ b/backend/api/views/SiteView.py
@@ -31,5 +31,4 @@ class SiteViewSet(viewsets.ModelViewSet):
         queryset = queryset.distinct()
         filter_query_set = self.filter_queryset(queryset)
         serializer = self.get_serializer_class()(filter_query_set, many=True)
-        # Return paginated response
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR address issue #210 

### Implementation

1. **backend/api/views/EventTypeView.py**
- Added ordering to the `EventTypeView` queryset.
- The ordering prioritizes `type`, followed by `distance`, and then `stroke`.
2. **backend/api/views/SiteView.py**
- Removed an unnecessary print statement.
- Ordering was already implemented and remains unchanged.
3. **backend/api/views/GroupView.py**
- Added ordering by `name`, but since `name` is not a field on the model, Django backend filters cannot be directly applied.
- To address this:
   -  Added an annotate method in `get_queryset` to dynamically construct name.
   - Included a priority list for gender, where `MX` comes before `Girls`, and `Girls` comes before `Boys`.


UI Preview

- `EventType` order:
![image](https://github.com/user-attachments/assets/24c1676d-876f-4ab7-af04-84deea906832)

- `Site` order:

![image](https://github.com/user-attachments/assets/c3824884-f51d-4e82-850e-829016fc43f0)


- `Group` order

![image](https://github.com/user-attachments/assets/ddc3143b-9354-4713-aa54-0855b7a13366)
