### PR TITLE
FE - Number of Lanes when creating a Swim Meet

### DIFF
--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -21,8 +21,9 @@ const AddSwimMeet = () => {
     handleSubmit,
     control,
     reset,
+    watch,
+    resetField,
     formState: { isDirty, isValid },
-    setValue,
   } = useForm({
     defaultValues: {
       name: "",
@@ -60,7 +61,7 @@ const AddSwimMeet = () => {
           return {
             id: site.id,
             name: site.name,
-            max_value: site.num_lanes,
+            num_lanes: site.num_lanes,
           };
         });
         if (!ignore) {
@@ -162,10 +163,11 @@ const AddSwimMeet = () => {
             <SwimMeetForm
               handleSubmit={handleSubmit(submission)}
               control={control}
+              resetField={resetField}
+              watch={watch}
               handleCancel={handleCancel}
               options={sites}
               isValid={isValid}
-              setValue={setValue}
             />
           </Stack>
         </Stack>

--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -22,12 +22,14 @@ const AddSwimMeet = () => {
     control,
     reset,
     formState: { isDirty, isValid },
+    setValue,
   } = useForm({
     defaultValues: {
       name: "",
       date: dayjs(Date.now()),
       time: dayjs(Date.now()),
       site: "",
+      num_lanes: "",
     },
     mode: "onChange",
   });
@@ -58,6 +60,7 @@ const AddSwimMeet = () => {
           return {
             id: site.id,
             name: site.name,
+            max_value: site.num_lanes,
           };
         });
         if (!ignore) {
@@ -66,7 +69,8 @@ const AddSwimMeet = () => {
             name: "",
             date: dayjs(Date.now()),
             time: dayjs(Date.now()),
-            site: _sites[0]?.id || "",
+            site: "",
+            num_lanes: "",
           });
         }
       } catch (error) {
@@ -121,7 +125,8 @@ const AddSwimMeet = () => {
       name: "",
       date: dayjs(Date.now()),
       time: dayjs(Date.now()),
-      site: sites[0].id,
+      site: "",
+      num_lanes: "",
     });
   };
 
@@ -160,6 +165,7 @@ const AddSwimMeet = () => {
               handleCancel={handleCancel}
               options={sites}
               isValid={isValid}
+              setValue={setValue}
             />
           </Stack>
         </Stack>

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -7,23 +7,24 @@ import MyTimePicker from "../components/FormElements/MyTimePicker.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
 import NumericalSelect from "../components/FormElements/NumericalSelect.jsx";
 import dayjs from "dayjs";
-import { useWatch } from "react-hook-form";
 import { useEffect } from "react";
 
 const SwimMeetForm = ({
   handleSubmit,
   control,
+  resetField,
+  watch,
   handleCancel,
   options,
   isValid,
-  setValue,
 }) => {
-  const selectedSite = useWatch({ control, name: "site" });
-  const selectedSiteData = options.find((option) => option.id === selectedSite);
-  const max_value = selectedSiteData ? selectedSiteData.max_value : 1;
+  const selectedSite = watch("site");
   useEffect(() => {
-    setValue("num_lanes", "");
+    resetField("num_lanes");
   }, [selectedSite]);
+  const selectedSiteData = options.find((option) => option.id === selectedSite);
+  const max_num_lanes = selectedSiteData ? selectedSiteData.num_lanes : "";
+
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
       <Stack>
@@ -85,7 +86,7 @@ const SwimMeetForm = ({
             name={"num_lanes"}
             control={control}
             min_value={1}
-            max_value={max_value}
+            max_value={max_num_lanes}
             disabled={!selectedSite}
             rules={{
               required: "Number of lanes is required",

--- a/frontend/src/SwimMeet/SwimMeetForm.jsx
+++ b/frontend/src/SwimMeet/SwimMeetForm.jsx
@@ -5,7 +5,10 @@ import MyButton from "../components/FormElements/MyButton.jsx";
 import MyDatePicker from "../components/FormElements/MyDatePicker.jsx";
 import MyTimePicker from "../components/FormElements/MyTimePicker.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
+import NumericalSelect from "../components/FormElements/NumericalSelect.jsx";
 import dayjs from "dayjs";
+import { useWatch } from "react-hook-form";
+import { useEffect } from "react";
 
 const SwimMeetForm = ({
   handleSubmit,
@@ -13,7 +16,14 @@ const SwimMeetForm = ({
   handleCancel,
   options,
   isValid,
+  setValue,
 }) => {
+  const selectedSite = useWatch({ control, name: "site" });
+  const selectedSiteData = options.find((option) => option.id === selectedSite);
+  const max_value = selectedSiteData ? selectedSiteData.max_value : 1;
+  useEffect(() => {
+    setValue("num_lanes", "");
+  }, [selectedSite]);
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
       <Stack>
@@ -31,14 +41,17 @@ const SwimMeetForm = ({
             name={"date"}
             control={control}
             disablePast={true}
-            rules={{ required: "Date is required",
+            rules={{
+              required: "Date is required",
               validate: (value) => {
                 if (!dayjs(value).isValid()) return "Invalid date";
-                if (dayjs(value).startOf('day').isBefore(dayjs().startOf('day')))
+                if (
+                  dayjs(value).startOf("day").isBefore(dayjs().startOf("day"))
+                )
                   return "Date cannot be in the past";
                 return true;
               },
-             }}
+            }}
           />
         </Box>
         <Box className={"itemBox"}>
@@ -63,6 +76,19 @@ const SwimMeetForm = ({
             options={options}
             rules={{
               required: "Site is required",
+            }}
+          />
+        </Box>
+        <Box className={"itemBox"}>
+          <NumericalSelect
+            label={"Number of Lanes"}
+            name={"num_lanes"}
+            control={control}
+            min_value={1}
+            max_value={max_value}
+            disabled={!selectedSite}
+            rules={{
+              required: "Number of lanes is required",
             }}
           />
         </Box>

--- a/frontend/src/components/FormElements/NumericalSelect.jsx
+++ b/frontend/src/components/FormElements/NumericalSelect.jsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { Controller } from "react-hook-form";
+import {
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl,
+  FormHelperText,
+} from "@mui/material";
+
+const NumericalSelect = (props) => {
+  const { label, name, control, min_value, max_value, rules } = props;
+  const options = Array.from(
+    { length: max_value - min_value + 1 },
+    (_, index) => min_value + index
+  );
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <FormControl fullWidth error={!!error} variant="outlined">
+          <InputLabel>{label}</InputLabel>
+          <Select
+            value={value}
+            onChange={onChange}
+            label={label}
+            sx={{ minWidth: 250 }}
+          >
+            {options.map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+          {error && <FormHelperText>{error.message}</FormHelperText>}
+        </FormControl>
+      )}
+    />
+  );
+};
+
+export default NumericalSelect;

--- a/frontend/src/components/FormElements/NumericalSelect.jsx
+++ b/frontend/src/components/FormElements/NumericalSelect.jsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 
 const NumericalSelect = (props) => {
-  const { label, name, control, min_value, max_value, rules } = props;
+  const { label, name, control, min_value, max_value, disabled, rules } = props;
   const options = Array.from(
     { length: max_value - min_value + 1 },
     (_, index) => min_value + index
@@ -27,6 +27,7 @@ const NumericalSelect = (props) => {
             value={value}
             onChange={onChange}
             label={label}
+            disabled={disabled}
             sx={{ minWidth: 250 }}
           >
             {options.map((option) => (


### PR DESCRIPTION
This PR addresses issue #212. 

### Implementation

1. New component

- frontend/src/components/FormElements/NumericalSelect.jsx
  - Created a reusable `NumericalSelect` component that allows users to select an integer between a `min_value` and `max_value`.

2. Modifications to existing components

- frontend/src/SwimMeet/SwimMeetForm.jsx
  - Added `NumericalSelect` to allow users to select the number of lanes for a swim meet.
  - The `NumericalSelect` is **disabled** if no site is selected.
  - The `max_value` dynamically updates to match the number of lanes available at the selected site.
  - When the `site` selection changes, `NumericalSelect` is reset accordingly.
  
- frontend/src/SwimMeet/AddSwimMeet.jsx
  - Included `num_lanes` in the form to store the selected number of lanes.

