### PR TITLE
FE-Fix NumLanes prop on SwimMeetDisplay

### DIFF
--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -307,7 +307,7 @@ const MeetEventDisplay = () => {
           <EventDetails
             eventName={currentEvent.name}
             eventId={currentEvent.id}
-            numLanes={meetData.site_num_lanes}
+            numLanes={meetData.num_lanes}
             onBack={handleBackToEvents}
             onPrevious={handlePreviousEvent}
             onNext={handleNextEvent}


### PR DESCRIPTION
This PR addresses issue #238 

### Implementation

- Updated File: **frontend/src/Event/MeetEventDisplay.jsx**
- `meetData` no longer contains `site_num_lanes`; it has been replaced with `num_lanes`.
- In `EventDetails`, `numLanes` is now assigned from `meetData.num_lanes`.