### PR TITLE
FE - AddEvent popup

### DIFF
--- a/frontend/src/Event/AddEvent.jsx
+++ b/frontend/src/Event/AddEvent.jsx
@@ -8,7 +8,12 @@ import AlertBox from "../components/Common/AlertBox.jsx";
 import { SmmApi } from "../SmmApi.jsx";
 import AddEventForm from "./AddEventForm.jsx";
 
-const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
+const AddEvent = ({
+  onBack,
+  setNumNewEvents,
+  setLastEventCreated,
+  setRequiredGenerate,
+}) => {
   const { meetId } = useParams();
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -82,10 +87,15 @@ const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
     };
   }, []);
 
+  const handleGoToGenerate = () => {
+    setRequiredGenerate(true);
+    onBack();
+  };
+
   let actionButtonsSuccess = [
     {
       label: "Create Heats",
-      onClick: onCreateHeats,
+      onClick: handleGoToGenerate,
       icon: <BuildIcon />,
     },
   ];
@@ -95,7 +105,8 @@ const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
   const submission = async (data) => {
     try {
       const response = await SmmApi.createEvent(meetId, data);
-      onCreateEvent();
+      setLastEventCreated(response.data.id);
+      setNumNewEvents(1);
       setError(false);
     } catch (error) {
       if (error.response && error.response.status === 400) {
@@ -152,10 +163,16 @@ const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
       );
     }
     return (
-      <div>
-        {!submitted && <div style={{ minHeight: "100px" }} />}
+      <div
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
         <Stack alignItems="center" justifyContent="space-between">
           <Stack alignItems="center" justifyContent="space-between">
+            {!submitted && <div style={{ minHeight: "100px" }} />}
             {submitted && (
               <AlertBox
                 type={typeAlert}
@@ -172,6 +189,7 @@ const AddEvent = ({ onBack, onCreateHeats, onCreateEvent }) => {
               options={{ groups, eventTypes }}
             />
           </Stack>
+          <div style={{ minHeight: "100px" }}></div>
         </Stack>
       </div>
     );

--- a/frontend/src/Event/AddEvent.jsx
+++ b/frontend/src/Event/AddEvent.jsx
@@ -25,7 +25,7 @@ const AddEvent = ({
     handleSubmit,
     control,
     reset,
-    formState: { isDirty },
+    formState: { isDirty, isValid },
   } = useForm({
     defaultValues: {
       group: "",
@@ -69,11 +69,6 @@ const AddEvent = ({
         if (!ignore) {
           setGroups(_groups);
           setEventTypes(_eventTypes);
-
-          reset({
-            event_type: _eventTypes[0]?.id || "",
-            group: _groups[0]?.id || "",
-          });
         }
       } catch (error) {
         setErrorOnLoading(true);
@@ -121,10 +116,6 @@ const AddEvent = ({
       }
     }
     setSubmitted(true);
-    reset({
-      group: groups[0]?.id || "",
-      event_type: eventTypes[0]?.id || "",
-    });
   };
 
   let actionButtonsErrorOnLoading = [
@@ -187,6 +178,7 @@ const AddEvent = ({
               control={control}
               handleCancel={onBack}
               options={{ groups, eventTypes }}
+              isValid={isValid}
             />
           </Stack>
           <div style={{ minHeight: "100px" }}></div>

--- a/frontend/src/Event/AddEventForm.jsx
+++ b/frontend/src/Event/AddEventForm.jsx
@@ -3,7 +3,13 @@ import { Box, Stack, Typography, Divider } from "@mui/material";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
 
-const AddEventForm = ({ handleSubmit, control, handleCancel, options }) => {
+const AddEventForm = ({
+  handleSubmit,
+  control,
+  handleCancel,
+  options,
+  isValid,
+}) => {
   const { groups, eventTypes } = options;
 
   return (
@@ -41,7 +47,12 @@ const AddEventForm = ({ handleSubmit, control, handleCancel, options }) => {
         </Box>
       </Stack>
       <Stack className={"itemBox"}>
-        <MyButton key={"create"} label={"Create"} type={"submit"} />
+        <MyButton
+          key={"create"}
+          label={"Create"}
+          type={"submit"}
+          disabled={!isValid}
+        />
         <Box sx={{ marginTop: 2 }}></Box>
         <MyButton
           key={"cancel"}

--- a/frontend/src/Event/AddEventForm.jsx
+++ b/frontend/src/Event/AddEventForm.jsx
@@ -1,5 +1,5 @@
 import "../App.css";
-import { Box, Stack} from "@mui/material";
+import { Box, Stack, Typography, Divider } from "@mui/material";
 import MyButton from "../components/FormElements/MyButton.jsx";
 import MySelect from "../components/FormElements/MySelect.jsx";
 
@@ -8,35 +8,47 @@ const AddEventForm = ({ handleSubmit, control, handleCancel, options }) => {
 
   return (
     <form onSubmit={handleSubmit} className={"whiteBox"}>
-        <Stack>
-          <Box className={"itemBox"}>
-            <MySelect
-              label={"Group"}
-              name={"group"}
-              control={control}
-              options={groups}
-              rules={{ required: "Group is required" }}
-            />
-          </Box>
-          <Box className={"itemBox"}>
-            <MySelect
-              label={"Event Type"}
-              name={"event_type"}
-              control={control}
-              options={eventTypes}
-              rules={{ required: "Event Type is required" }}
-            />
-          </Box>
-        </Stack>
-        <Stack className={"itemBox"}>
-          <MyButton key={"create"} label={"Create"} type={"submit"} />
-          <Box sx={{ marginTop: 2 }}></Box>
-          <MyButton
-            key={"cancel"}
-            label={"Go to Events"}
-            onClick={handleCancel}
+      <Stack>
+        <Box>
+          <Typography
+            variant="subtitle1"
+            color="primary"
+            padding={0.5}
+            align="center"
+            style={{ fontWeight: 600 }}
+          >
+            {"ADD EVENT"}
+          </Typography>
+        </Box>
+        <Divider sx={{ borderBottomWidth: 3 }}></Divider>
+        <Box className={"itemBox"}>
+          <MySelect
+            label={"Group"}
+            name={"group"}
+            control={control}
+            options={groups}
+            rules={{ required: "Group is required" }}
           />
-        </Stack>
+        </Box>
+        <Box className={"itemBox"}>
+          <MySelect
+            label={"Event Type"}
+            name={"event_type"}
+            control={control}
+            options={eventTypes}
+            rules={{ required: "Event Type is required" }}
+          />
+        </Box>
+      </Stack>
+      <Stack className={"itemBox"}>
+        <MyButton key={"create"} label={"Create"} type={"submit"} />
+        <Box sx={{ marginTop: 2 }}></Box>
+        <MyButton
+          key={"cancel"}
+          label={"Go to Events"}
+          onClick={handleCancel}
+        />
+      </Stack>
     </form>
   );
 };

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -7,7 +7,7 @@ import {
   EmojiEvents as RankingIcon,
 } from "@mui/icons-material";
 import { CircularProgress, Box, Stack, Dialog } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import GenerateHeats from "../Heat/GenerateHeats.jsx";
 import { SmmApi } from "../SmmApi.jsx";
@@ -49,6 +49,9 @@ const MeetEventDisplay = () => {
 
   //Add states
   const [newEventTigger, setNewEventTrigger] = useState(0);
+  const numEventsCreated = useRef(0);
+  const lastCreatedEventId = useRef(null);
+  const requiredGenerate = useRef(false);
 
   //GenerateHeats states
   const [reloadEventDataTrigger, setReloadEventDataTrigger] = useState(0);
@@ -163,7 +166,19 @@ const MeetEventDisplay = () => {
           } else if (navegationDirection === "next") {
             setSelectedEventIndex(0);
           }
+          if (lastCreatedEventId.current != null) {
+            const indexEvent = json.results.findIndex(
+              (item) => item.id === lastCreatedEventId.current
+            );
+            setSelectedEventIndex(indexEvent);
+          }
+          if (requiredGenerate.current) {
+            setView("generate");
+          }
           setNavegationDirection(null);
+          numEventsCreated.current = 0;
+          lastCreatedEventId.current = null;
+          requiredGenerate.current = false;
         }
       } catch (error) {
         setErrorOnLoading(true);
@@ -178,12 +193,11 @@ const MeetEventDisplay = () => {
   }, [offset, limit, reloadEventDataTrigger]);
 
   useEffect(() => {
-    const lastIndex = count % limit;
-    const lastOffset = count - lastIndex;
-    const lastPage = ~~(count / limit);
-    setSelectedEventIndex(lastIndex);
+    const total_count = count + numEventsCreated.current - 1;
+    const lastIndex = total_count % limit;
+    const lastOffset = total_count - lastIndex;
+    const lastPage = ~~(total_count / limit);
     setPage(lastPage);
-    // On reload data once
     offset !== lastOffset
       ? setOffset(lastOffset)
       : setReloadEventDataTrigger((prev) => prev + 1);
@@ -193,13 +207,15 @@ const MeetEventDisplay = () => {
     setIsFormOpen(true);
   };
 
-  const handleNewEventCreated = () => {
+  const handleBackToEventsFromNewEvent = () => {
     setNewEventTrigger((prev) => prev + 1);
+    setIsFormOpen(false);
   };
 
   const handleBackToEvents = () => {
-    //Need to reload to the last event
-    setIsFormOpen(false);
+    setReloadEventDataTrigger((prev) => prev + 1);
+    setSelectedEventIndex(null);
+    setView("list");
   };
 
   const handleGenerateButtonOnEventDetails = () => {
@@ -242,14 +258,6 @@ const MeetEventDisplay = () => {
     } else {
       setSelectedEventIndex(index);
       setView("details");
-    }
-  };
-
-  const handleAddHeatsToNewEvent = () => {
-    if (selectedEventIndex === null) {
-      setView("list");
-    } else {
-      setView("generate");
     }
   };
 
@@ -323,14 +331,6 @@ const MeetEventDisplay = () => {
             onProcessCompletion={handleGenerateHeatProcessCompletion}
           />
         );
-      case "add":
-        return (
-          <AddEvent
-            onBack={handleBackToEvents}
-            onCreateHeats={handleAddHeatsToNewEvent}
-            onCreateEvent={handleNewEventCreated}
-          />
-        );
       case "results":
         return (
           <EventResults
@@ -402,9 +402,12 @@ const MeetEventDisplay = () => {
             />
             <Dialog open={isFormOpen} fullWidth>
               <AddEvent
-                onBack={handleBackToEvents}
-                onCreateHeats={handleAddHeatsToNewEvent}
-                onCreateEvent={handleNewEventCreated}
+                onBack={handleBackToEventsFromNewEvent}
+                setNumNewEvents={(num) => (numEventsCreated.current += num)}
+                setLastEventCreated={(id) => (lastCreatedEventId.current = id)}
+                setRequiredGenerate={(value) =>
+                  (requiredGenerate.current = value)
+                }
               />
             </Dialog>
           </>

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -40,7 +40,7 @@ const MeetEventDisplay = () => {
   const [eventData, setEventData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
-  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(location.state?.showAddEvent ? true : false);
 
   // View states
   const [view, setView] = useState("list");

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -42,9 +42,7 @@ const MeetEventDisplay = () => {
   const [errorOnLoading, setErrorOnLoading] = useState(false);
 
   // View states
-  const [view, setView] = useState(
-    location.state?.showAddEvent ? "add" : "list"
-  );
+  const [view, setView] = useState("list");
   const [selectedEventIndex, setSelectedEventIndex] = useState(null);
   const [navegationDirection, setNavegationDirection] = useState(null);
 

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -6,7 +6,7 @@ import {
   FormatAlignCenter as HeatIcon,
   EmojiEvents as RankingIcon,
 } from "@mui/icons-material";
-import { CircularProgress, Box, Stack } from "@mui/material";
+import { CircularProgress, Box, Stack, Dialog } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import GenerateHeats from "../Heat/GenerateHeats.jsx";
@@ -40,6 +40,7 @@ const MeetEventDisplay = () => {
   const [eventData, setEventData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
 
   // View states
   const [view, setView] = useState("list");
@@ -189,8 +190,7 @@ const MeetEventDisplay = () => {
   }, [newEventTigger]);
 
   const handleAddNew = () => {
-    setSelectedEventIndex(null);
-    setView("add");
+    setIsFormOpen(true);
   };
 
   const handleNewEventCreated = () => {
@@ -198,9 +198,8 @@ const MeetEventDisplay = () => {
   };
 
   const handleBackToEvents = () => {
-    setReloadEventDataTrigger((prev) => prev + 1);
-    setSelectedEventIndex(null);
-    setView("list");
+    //Need to reload to the last event
+    setIsFormOpen(false);
   };
 
   const handleGenerateButtonOnEventDetails = () => {
@@ -401,6 +400,13 @@ const MeetEventDisplay = () => {
               page={page}
               setPage={setPage}
             />
+            <Dialog open={isFormOpen} fullWidth>
+              <AddEvent
+                onBack={handleBackToEvents}
+                onCreateHeats={handleAddHeatsToNewEvent}
+                onCreateEvent={handleNewEventCreated}
+              />
+            </Dialog>
           </>
         );
     }

--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -90,7 +90,7 @@ const AddSwimMeet = () => {
 
   const handleAddEvents = () => {
     navigate(`/swim-meets/${lastSwimMeetData.id}/events`, {
-      state: { meetData: lastSwimMeetData },
+      state: { showAddEvent: true, meetData: lastSwimMeetData },
     });
   };
 

--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -90,7 +90,7 @@ const AddSwimMeet = () => {
 
   const handleAddEvents = () => {
     navigate(`/swim-meets/${lastSwimMeetData.id}/events`, {
-      state: { showAddEvent: true, meetData: lastSwimMeetData },
+      state: { meetData: lastSwimMeetData },
     });
   };
 


### PR DESCRIPTION
This PR addresses issue #243.

### Implementation

- Refactored Components:

  - **frontend/src/Event/AddEvent.jsx**
  - **frontend/src/Event/MeetEventDisplay.jsx**

- Appearance Changes:

  - `AddEvent` now displays as a popup.
  - `AddEvent` styling is the same as all the other popup forms.
  
- Behavior Changes:
  - When creating events, two refs track the creation process:
    - `numEventsCreated`: Tracks the number of events created.
    - `lastCreatedEventId`: Stores the **ID** of the last created event.
  - When returning to `MeetEventDisplay`:
    - The required `offset` is calculated using `numEventsCreated` to ensure the last created event appears in the display table.
    - The data is reloaded with the updated offset.
    - `lastCreatedEventId` helps identify the table index of the last created event (needed for displaying the generate view).
    - `requiredGenerate` determines whether to show the generate view or the list view.
    - `numEventsCreated`, `lastCreatedEventId` and `requiredGenerate` are cleared after all calculations are completed.
