### PR TITLE
FE-EventDetails Bug Fix

### DIFF
--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -143,23 +143,25 @@ const EventDetails = ({
       );
     }
     if (numHeats === 0) {
-      <>
-        <Stack
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "16px",
-            width: "500px",
-            margin: "auto",
-          }}
-        >
-          <AlertBox
-            type="info"
-            message="This event has no heats yet."
-            actionButtons={actionButtonsNoHeats}
-          />
-        </Stack>
-      </>;
+      return (
+        <>
+          <Stack
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+              width: "500px",
+              margin: "auto",
+            }}
+          >
+            <AlertBox
+              type="info"
+              message="This event has no heats yet."
+              actionButtons={actionButtonsNoHeats}
+            />
+          </Stack>
+        </>
+      );
     }
     return null;
   };


### PR DESCRIPTION
This PR addresses issue #244 

### Implementation

- **File**: frontend/src/Event/EventDetails.jsx
- **Fix**: Added a return statement in `renderContent` when `numHeats` is zero (line 145).
- **Result**: The alert box is now visible.

![image](https://github.com/user-attachments/assets/dfe34416-2ed0-4d37-a72f-c387ba20eb2e)
