### PR TITLE
BE- Enrollment Endpoints 

### DIFF
--- a/backend/api/serializers/EnrollmentSerializer.py
+++ b/backend/api/serializers/EnrollmentSerializer.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+from api.models import Enrollment, SwimMeet, Athlete
+
+
+class EnrollAthletesListSerializer(serializers.Serializer):
+    athlete_ids = serializers.ListField(
+        child=serializers.IntegerField(), allow_empty=False)
+
+    def validate_athlete_ids(self, value):
+        swim_meet_id = self.context.get('meet_id')
+        if not swim_meet_id:
+            raise serializers.ValidationError(
+                "Swim meet id is required for validation")
+
+        athlete_ids_set = set(value)
+
+        # Check if all athletes_ids exist
+        existing_athletes_ids = set(
+            Athlete.objects.values_list('id', flat=True))
+        invalid_ids = athlete_ids_set - existing_athletes_ids
+
+        if invalid_ids:
+            raise serializers.ValidationError(
+                f"Invalid athletes ids: {list(invalid_ids)}")
+
+        # Get enrolled athlete_ids for the swim meet
+        enrolled_athletes_ids = set(
+            Enrollment.objects.filter(swim_meet_id=swim_meet_id)
+            .values_list('athlete_id', flat=True)
+        )
+
+        already_enrolled = athlete_ids_set & enrolled_athletes_ids  # Intersection
+
+        print(set(value), set(enrolled_athletes_ids))
+        print(enrolled_athletes_ids, invalid_ids)
+
+        if already_enrolled:
+            raise serializers.ValidationError(
+                f"Athlete(s) already enrolled in this swim meet: {list(already_enrolled)}"
+            )
+        return list(athlete_ids_set)
+
+
+class UnenrollAthleteSerializer(serializers.Serializer):
+    athlete_id = serializers.IntegerField()
+
+    def validate_athlete_id(self, value):
+        swim_meet_id = self.context.get('meet_id')
+
+        if not swim_meet_id:
+            raise serializers.ValidationError(
+                "Swim meet id is required for validation")
+
+        swim_meet = SwimMeet.objects.filter(id=swim_meet_id).first()
+
+        if not swim_meet:
+            raise serializers.ValidationError("Swim meet not found")
+
+        athlete = Athlete.objects.filter(id=value).first()
+        if not athlete:
+            raise serializers.ValidationError("Athlete not found")
+
+        if not Enrollment.objects.filter(swim_meet=swim_meet, athlete=athlete).exists():
+            raise serializers.ValidationError(
+                "Athlete is not enrolled in this swim meet")
+        return value

--- a/backend/api/serializers/EnrollmentSerializer.py
+++ b/backend/api/serializers/EnrollmentSerializer.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from api.models import Enrollment, SwimMeet, Athlete
+from api.models import Enrollment, Athlete
 
 
 class EnrollAthletesListSerializer(serializers.Serializer):
@@ -48,11 +48,10 @@ class UnenrollAthleteSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "Swim meet id is required for validation")
 
-        athlete = Athlete.objects.filter(id=value).first()
-        if not athlete:
+        if not Athlete.objects.filter(id=value).exists():
             raise serializers.ValidationError("Athlete not found")
 
-        if not Enrollment.objects.filter(swim_meet=swim_meet_id, athlete=athlete).exists():
+        if not Enrollment.objects.filter(swim_meet=swim_meet_id, athlete=value).exists():
             raise serializers.ValidationError(
                 "Athlete is not enrolled in this swim meet")
         return value

--- a/backend/api/serializers/EnrollmentSerializer.py
+++ b/backend/api/serializers/EnrollmentSerializer.py
@@ -31,9 +31,6 @@ class EnrollAthletesListSerializer(serializers.Serializer):
 
         already_enrolled = athlete_ids_set & enrolled_athletes_ids  # Intersection
 
-        print(set(value), set(enrolled_athletes_ids))
-        print(enrolled_athletes_ids, invalid_ids)
-
         if already_enrolled:
             raise serializers.ValidationError(
                 f"Athlete(s) already enrolled in this swim meet: {list(already_enrolled)}"

--- a/backend/api/serializers/EnrollmentSerializer.py
+++ b/backend/api/serializers/EnrollmentSerializer.py
@@ -16,7 +16,10 @@ class EnrollAthletesListSerializer(serializers.Serializer):
 
         # Check if all athletes_ids exist
         existing_athletes_ids = set(
-            Athlete.objects.values_list('id', flat=True))
+            Athlete.objects.filter(
+                id__in=athlete_ids_set).values_list('id', flat=True)
+        )
+
         invalid_ids = athlete_ids_set - existing_athletes_ids
 
         if invalid_ids:

--- a/backend/api/serializers/EnrollmentSerializer.py
+++ b/backend/api/serializers/EnrollmentSerializer.py
@@ -48,16 +48,11 @@ class UnenrollAthleteSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "Swim meet id is required for validation")
 
-        swim_meet = SwimMeet.objects.filter(id=swim_meet_id).first()
-
-        if not swim_meet:
-            raise serializers.ValidationError("Swim meet not found")
-
         athlete = Athlete.objects.filter(id=value).first()
         if not athlete:
             raise serializers.ValidationError("Athlete not found")
 
-        if not Enrollment.objects.filter(swim_meet=swim_meet, athlete=athlete).exists():
+        if not Enrollment.objects.filter(swim_meet=swim_meet_id, athlete=athlete).exists():
             raise serializers.ValidationError(
                 "Athlete is not enrolled in this swim meet")
         return value

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -19,6 +19,8 @@ from api.views.EventResultView import EventResultView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 from api.views.download.DownloadResults import DownloadEventResults
 from api.views.download.DownloadResults import DownloadEventResultsForSwimMeet
+from api.views.EnrollmentView import MeetEnrolledAthletes, MeetUnenrolledAthletes
+
 
 from rest_framework.routers import SimpleRouter
 
@@ -31,7 +33,6 @@ router.register(r'session', SessionViewSet, basename='session')
 router.register(r'swimmeet', SwimMeetViewSet, basename='swimmeet')
 router.register(r'athlete', AthleteViewSet, basename='athlete')
 router.register(r'timerecord', TimeRecordViewSet, basename='timerecord')
-
 
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view()),
@@ -62,7 +63,12 @@ urlpatterns = [
     path('download-all-event-results/<int:meet_id>/',
          DownloadEventResultsForSwimMeet.as_view(), name='download-all-events-results'),
     path('event_lane/update_heat_times/',
-         UpdateHeatTimeView.as_view(), name='update-heat-time')
+         UpdateHeatTimeView.as_view(), name='update-heat-time'),
+    path('meet_enroll/<int:meet_id>/',
+         MeetEnrolledAthletes.as_view(), name='meet-enroll'),
+    path('meet_unenrolled/<int:meet_id>/',
+         MeetUnenrolledAthletes.as_view(), name='meet-unenrolled-athletes'),
+
 ]
 
 urlpatterns += router.urls

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -73,12 +73,17 @@ class MeetEnrolledAthletes(APIView):
                    summary="Unenroll an Athlete from a specific swim meet",
                    description="Accepts an athlete ID already enrolled on the swim meet and unenrolls them")
     def patch(self, request, meet_id):
+        try:
+            swim_meet = SwimMeet.objects.get(id=meet_id)
+        except SwimMeet.DoesNotExist:
+            return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)
+
         serializer = UnenrollAthleteSerializer(
             data=request.data, context={"meet_id": meet_id})
         if serializer.is_valid():
             athlete_id = serializer.validated_data['athlete_id']
             Enrollment.objects.filter(
-                swim_meet_id=meet_id, athlete_id=athlete_id).delete()
+                swim_meet_id=swim_meet, athlete_id=athlete_id).delete()
             return Response({"success": "Athlete unenrolled successfully"}, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -21,11 +21,9 @@ class MeetEnrolledAthletes(APIView):
         except SwimMeet.DoesNotExist:
             return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)
 
-        enrollments = Enrollment.objects.filter(swim_meet=swim_meet).order_by(
-            'athlete__first_name', 'athlete__last_name'
-        )
-        athletes = [
-            enrollment.athlete for enrollment in enrollments if enrollment.athlete]
+        athletes = Athlete.objects.filter(
+            athlete_swim_meets__swim_meet=swim_meet).order_by('first_name', 'last_name')
+
         serializer = AthleteSerializer(athletes, many=True)
         return Response(serializer.data)
 

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -76,7 +76,6 @@ class MeetEnrolledAthletes(APIView):
         serializer = UnenrollAthleteSerializer(
             data=request.data, context={"meet_id": meet_id})
         if serializer.is_valid():
-            print(serializer.validated_data)
             athlete_id = serializer.validated_data['athlete_id']
             Enrollment.objects.filter(
                 swim_meet_id=meet_id, athlete_id=athlete_id).delete()

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -1,0 +1,106 @@
+from rest_framework import status
+from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, OpenApiExample
+from api.models import Enrollment, SwimMeet, Athlete
+from api.serializers.EnrollmentSerializer import UnenrollAthleteSerializer, EnrollAthletesListSerializer
+from api.serializers.AthleteSerializer import AthleteSerializer
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from django.db import transaction
+
+
+@extend_schema(tags=['Swim Meet - Enrollment'])
+class MeetEnrolledAthletes(APIView):
+
+    @extend_schema(methods=['GET'],
+                   summary="List enrolled athletes on a swim meet",
+                   description="Lists all the athletes enrolled on a specific meet, ordered alphabetically by name")
+    def get(self, request, meet_id):
+        try:
+            swim_meet = SwimMeet.objects.get(id=meet_id)
+        except SwimMeet.DoesNotExist:
+            return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        enrollments = Enrollment.objects.filter(swim_meet=swim_meet).order_by(
+            'athlete__first_name', 'athlete__last_name'
+        )
+        athletes = [
+            enrollment.athlete for enrollment in enrollments if enrollment.athlete]
+        serializer = AthleteSerializer(athletes, many=True)
+        return Response(serializer.data)
+
+    @extend_schema(methods=['POST'],
+                   request=EnrollAthletesListSerializer,
+                   summary="Enroll a list of athletes to a specific swim meet",
+                   description="Accepts a list of athlete IDs that are not already enrolled in the swim meet and enrolls them",
+                   )
+    @transaction.atomic
+    def post(self, request, meet_id):
+        try:
+            swim_meet = SwimMeet.objects.get(id=meet_id)
+        except SwimMeet.DoesNotExist:
+            return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        athlete_ids = request.data.get('athlete_ids', [])
+
+        if not isinstance(athlete_ids, list):
+            return Response({'error': 'athlete_ids must be a list'}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = EnrollAthletesListSerializer(
+            data=request.data, context={'meet_id': meet_id})
+
+        if serializer.is_valid():
+            athlete_ids = serializer.validated_data['athlete_ids']
+
+            enrollments = [Enrollment(
+                swim_meet=swim_meet, athlete_id=athlete_id) for athlete_id in athlete_ids]
+            Enrollment.objects.bulk_create(enrollments)
+
+            return Response({"success": "Athlete(s) enrolled successfully"}, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @extend_schema(methods=['PATCH'],
+                   request=UnenrollAthleteSerializer,
+                   examples=[
+                   OpenApiExample(
+                       "Example Value",
+                       summary="Example of a Patch request",
+                       value={
+                           "athlete_id": 1,
+                       },
+                   )],
+                   summary="Unenroll an Athlete from a specific swim meet",
+                   description="Accepts an athlete ID already enrolled on the swim meet and unenrolls them")
+    def patch(self, request, meet_id):
+        serializer = UnenrollAthleteSerializer(
+            data=request.data, context={"meet_id": meet_id})
+        if serializer.is_valid():
+            print(serializer.validated_data)
+            athlete_id = serializer.validated_data['athlete_id']
+            Enrollment.objects.filter(
+                swim_meet_id=meet_id, athlete_id=athlete_id).delete()
+            return Response({"success": "Athlete unenrolled successfully"}, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@extend_schema(tags=['Swim Meet - Enrollment'])
+class MeetUnenrolledAthletes(APIView):
+
+    @extend_schema(
+        summary="List active athletes not enrolled in a swim meet",
+        description="Returns a list of active athletes not enrolled on a specified swim meet, ordered alphabetically by name",
+    )
+    def get(self, request, meet_id):
+        try:
+            swim_meet = SwimMeet.objects.get(id=meet_id)
+        except SwimMeet.DoesNotExist:
+            return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)
+        enrolled_athletes = Enrollment.objects.filter(
+            swim_meet=swim_meet).values_list("athlete_id", flat=True)
+        active_athletes = Athlete.objects.exclude(
+            id__in=enrolled_athletes).order_by('first_name', 'last_name')
+
+        serializer = AthleteSerializer(active_athletes, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
This PR addresses issue #225.

**Implementation**

1.  **backend/api/serializers/EnrollmentSerializer.py**
-  Created `EnrollAthletesListSerializer` based on `Serializer` to accept a list of IDs. This serializer validates the existence of an Athlete for each ID in the list. It also validates that the IDs are not already enrolled in the given swim meet.
It raise a ValidationError if there are invalid athletes IDs (not existing or already enrolled).

-  Created `UnenrollAthleteSerializer` based on `Serializer` to accept an athlete_id. This serializer validates the existence of the Athlete for the given athlete_id. It also validates that the athlete_id is already enrolled in the given swim meet.
It raise a ValidationError if the athlete_id is invalid(not exists or not enrolled).


2.  **backend/api/views/EnrollmentView.py**
Created an APIView named MeetEnrolledAthletes with:

- `get` method to list all the athletes enrolled on a specific meet, ordered alphabetically by name. This view uses the `AthleteSerializer`.
- `post` method to enroll a list of athletes to a specific swim meet. Uses the `EnrollAthletesListSerializer`.
- `patch` method to unenroll an Athlete from a specific swim meet. Uses the `UnenrollAthleteSerializer`.

Created an APIView named MeetUnenrolledAthletes with:
- `get` method to list all the athletes not enrolled on a specific meet, ordered alphabetically by name. This view uses the `AthleteSerializer`.

3. **backend/api/urls.py**

Added the following endpoints:

- `meet_enroll/<int:meet_id>/`  uses `MeetEnrolledAthletes`.
- `meet_unenrolled/<int:meet_id>/`  uses `MeetUnenrolledAthletes`.


**Swagger**
![Screenshot 2025-02-11 at 12 48 34 PM](https://github.com/user-attachments/assets/5e4108c6-a0ad-4260-ad80-8e2b092fe79e)

