### PR TITLE
BUG Search Bar Input Clears After Search 

### DIFF
--- a/frontend/src/Athlete/AthleteDisplay.jsx
+++ b/frontend/src/Athlete/AthleteDisplay.jsx
@@ -145,17 +145,6 @@ const AthleteDisplay = () => {
   ];
 
   const renderContent = () => {
-    if (loading) {
-      return (
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          style={{ height: "100px" }}
-        >
-          <CircularProgress />
-        </Stack>
-      );
-    }
     if (errorOnLoading) {
       return (
         <Stack
@@ -197,19 +186,32 @@ const AthleteDisplay = () => {
               ></SearchBar>
             </Box>
           </Stack>
-          <GenericTable
-            data={athleteData}
-            columns={columns}
-            actions={actions}
-          />
-          <PaginationBar
-            count={count}
-            setOffset={setOffset}
-            limit={limit}
-            setLimit={setLimit}
-            page={page}
-            setPage={setPage}
-          ></PaginationBar>
+          {loading && (
+            <Stack
+              alignItems="center"
+              justifyContent="center"
+              style={{ height: "100px" }}
+            >
+              <CircularProgress />
+            </Stack>
+          )}
+          {!loading && (
+            <>
+              <GenericTable
+                data={athleteData}
+                columns={columns}
+                actions={actions}
+              />
+              <PaginationBar
+                count={count}
+                setOffset={setOffset}
+                limit={limit}
+                setLimit={setLimit}
+                page={page}
+                setPage={setPage}
+              ></PaginationBar>
+            </>
+          )}
           <Dialog open={isFormOpen} fullWidth>
             <AddAthlete
               onCancel={handleCancelAddAthlete}

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -156,18 +156,6 @@ const SwimMeetDisplay = () => {
   ];
 
   const renderContent = () => {
-    if (loading) {
-      return (
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          style={{ height: "100px" }}
-        >
-          <CircularProgress />
-        </Stack>
-      );
-    }
-
     if (errorOnLoading) {
       return (
         <Stack
@@ -207,18 +195,31 @@ const SwimMeetDisplay = () => {
             ></SearchBar>
           </Box>
         </Stack>
-        <GenericTable data={data} columns={columns} actions={actions} />
-        <PaginationBar
-          count={count}
-          setOffset={setOffset}
-          limit={limit}
-          setLimit={setLimit}
-          page={page}
-          setPage={setPage}
-        ></PaginationBar>
-        <Dialog open={isFormOpen} fullWidth>
-          <AddSwimMeet onCancel={handleCancelAddSwimMeet} />
-        </Dialog>
+        {loading && (
+          <Stack
+            alignItems="center"
+            justifyContent="center"
+            style={{ height: "100px" }}
+          >
+            <CircularProgress />
+          </Stack>
+        )}
+        {!loading && (
+          <>
+            <GenericTable data={data} columns={columns} actions={actions} />
+            <PaginationBar
+              count={count}
+              setOffset={setOffset}
+              limit={limit}
+              setLimit={setLimit}
+              page={page}
+              setPage={setPage}
+            ></PaginationBar>
+            <Dialog open={isFormOpen} fullWidth>
+              <AddSwimMeet onCancel={handleCancelAddSwimMeet} />
+            </Dialog>
+          </>
+        )}
       </div>
     );
   };


### PR DESCRIPTION
This PR address issue #252 

### Causes of the bug

Each time a search is performed, data is fetched, triggering a re-render. During this process, a circular progress indicator is displayed, and the `SearchBar` component is re-rendered, causing it to lose the previous search input.

### Possible solutions

1. Pass the search parameter as a prop to `SearchBar` and use it as the default value in the form.
2. Keep the `SearchBar` fixed on the screen. When loading data, only the circular progress indicator should render in the same position as the data table.


### Implementation

This PR implements approach **2**:

- Removed the `if loading` condition from the `renderContent` function.
- The `Create` button and `SearchBar` now remain visible while loading.
- When `loading` is `true`, the circular progress indicator appears below the `Create` button and `SearchBar`.
- When `loading` is `false`, the data table and pagination bar are displayed as usual.

**Before the change**
![image](https://github.com/user-attachments/assets/64eb2d51-7a41-47e8-972e-6c6cd7196cf1)

**After the change**
![image](https://github.com/user-attachments/assets/b1116c26-f8dd-41ec-a8da-5a80e0590533)


### Components Affected

- SwimMeetDisplay
- AthleteDisplay

