### PR TITLE
FE- Add Enrollment API methods

### DIFF
--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -74,10 +74,14 @@ export class SmmApi {
     });
   }
 
-  static async logout( ) {
-    return await axios.post(`${BASE_URL}/logout/`, {}, {
-      headers: getConfig(),
-    });
+  static async logout() {
+    return await axios.post(
+      `${BASE_URL}/logout/`,
+      {},
+      {
+        headers: getConfig(),
+      }
+    );
   }
 
   static async getSwimMeetList(search, offset, limit) {
@@ -304,7 +308,7 @@ export class SmmApi {
     });
     return res.data;
   }
-  
+
   static async downloadResultsForEvent(swimMeetName, eventName, eventId, data) {
     try {
       const response = await axios.post(
@@ -410,5 +414,46 @@ export class SmmApi {
     return await axios.patch(`${BASE_URL}/athlete/${athleteId}/`, data, {
       headers: getConfig(),
     });
+  }
+
+  static async getSwimMeetEnrollment(meetId, search, offset, limit) {
+    let url = `${BASE_URL}/meet_enroll/${meetId}/`;
+    const extraParams = new URLSearchParams();
+
+    if (search) {
+      extraParams.set("search", search);
+    }
+    if (offset) {
+      extraParams.set("offset", offset);
+    }
+    if (limit) {
+      extraParams.set("limit", limit);
+    }
+
+    url += extraParams.toString();
+
+    let res = await axios.get(url, {
+      headers: getConfig(),
+    });
+    return res.data;
+  }
+
+  static async createSwimMeetEnrollment(meetId, data) {
+    return await axios.post(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
+      headers: getConfig(),
+    });
+  }
+
+  static async deleteSwimMeetEnrollment(meetId, data) {
+    let res = await axios.patch(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
+      headers: getConfig(),
+    });
+  }
+
+  static async getPotentialSwimMeetEnrollments(meetId) {
+    let res = await axios.get(`${BASE_URL}/meet_unenrolled/${meetId}/`, {
+      headers: getConfig(),
+    });
+    return res.data;
   }
 }

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -417,7 +417,7 @@ export class SmmApi {
   }
 
   static async getSwimMeetEnrollment(meetId, search, offset, limit) {
-    let url = `${BASE_URL}/meet_enroll/${meetId}/`;
+    let url = `${BASE_URL}/meet_enroll/${meetId}/?`;
     const extraParams = new URLSearchParams();
 
     if (search) {
@@ -445,7 +445,7 @@ export class SmmApi {
   }
 
   static async deleteSwimMeetEnrollment(meetId, data) {
-    let res = await axios.patch(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
+    return await axios.patch(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
       headers: getConfig(),
     });
   }

--- a/frontend/src/SmmApi.jsx
+++ b/frontend/src/SmmApi.jsx
@@ -416,7 +416,7 @@ export class SmmApi {
     });
   }
 
-  static async getSwimMeetEnrollment(meetId, search, offset, limit) {
+  static async getEnrolledAthletes(meetId, search, offset, limit) {
     let url = `${BASE_URL}/meet_enroll/${meetId}/?`;
     const extraParams = new URLSearchParams();
 
@@ -438,19 +438,19 @@ export class SmmApi {
     return res.data;
   }
 
-  static async createSwimMeetEnrollment(meetId, data) {
+  static async createEnrollment(meetId, data) {
     return await axios.post(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
       headers: getConfig(),
     });
   }
 
-  static async deleteSwimMeetEnrollment(meetId, data) {
+  static async deleteEnrolledAthlete(meetId, data) {
     return await axios.patch(`${BASE_URL}/meet_enroll/${meetId}/`, data, {
       headers: getConfig(),
     });
   }
 
-  static async getPotentialSwimMeetEnrollments(meetId) {
+  static async getUnenrolledAthletes(meetId) {
     let res = await axios.get(`${BASE_URL}/meet_unenrolled/${meetId}/`, {
       headers: getConfig(),
     });


### PR DESCRIPTION
This PR addresses issue #230 

### Description

This PR adds a new methods in the `SmmApi` class to handle API request to  get the enrolled/unenrolled athletes in a swim meet and to enroll/unenroll an athlete. 

### Implementation
In the `frontend/src/SmmApi.jsx` file, the following methods were added:

- `getSwimMeetEnrollment`: Sends a GET request to lists all the athletes enrolled on a specific meet, ordered alphabetically by first name and last name.
- `createSwimMeetEnrollment`: Sends a POST request to unenroll an athlete ID from the swim meet .
- `deleteSwimMeetEnrollment`: Sends a PATCH request to enroll a list of athlete IDs in the swim meet .
 - `getPotentialSwimMeetEnrollments`: Sends a GET request to lists all the active athletes not enrolled on a specified swim meet, ordered alphabetically by name.