### PR TITLE
BE- Update AthleteSeedTime View to consider Enrrollment

### DIFF
--- a/backend/api/views/AthleteSeedTimeView.py
+++ b/backend/api/views/AthleteSeedTimeView.py
@@ -35,7 +35,7 @@ class AthleteSeedTimeView(APIView):
             description='The initial index from which to return the results.',
         ),
     ],
-        summary="Retrieve a list of eligible athletes for a specific event along with their seed times")
+        summary="Retrieve the list of athletes enrolled in the swim meet, including their corresponding seed times for the given event.")
     def get(self, request, event_id):
         try:
             event_instance = MeetEvent.objects.get(id=event_id)

--- a/backend/api/views/AthleteSeedTimeView.py
+++ b/backend/api/views/AthleteSeedTimeView.py
@@ -8,60 +8,69 @@ from drf_spectacular.utils import extend_schema, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 from datetime import timedelta
 
+
 @extend_schema(tags=['Seed times'])
 class AthleteSeedTimeView(APIView):
-    def get_queryset(self, group_id,date_of_swim_meet):
-        queryset = Athlete.objects.all()
-        queryset = filter_by_group(group_id=group_id, queryset=queryset, date=date_of_swim_meet, from_athlete_model=True)
-            
+    def get_queryset(self, meet_id, group_id, date_of_swim_meet):
+        queryset = Athlete.objects.filter(
+            athlete_swim_meets__swim_meet=meet_id)
+        queryset = filter_by_group(
+            group_id=group_id, queryset=queryset, date=date_of_swim_meet, from_athlete_model=True)
+
         return queryset.order_by('first_name')
 
     @extend_schema(methods=['GET'],
                    request=AthleteSeedTimeSerializer,
                    parameters=[
-                        OpenApiParameter(
-                            name='limit',
-                            type=OpenApiTypes.INT,
-                            location=OpenApiParameter.QUERY,
-                            description='Number of results to return per page.',
-                        ),
-                        OpenApiParameter(
-                            name='offset',
-                            type=OpenApiTypes.INT,
-                            location=OpenApiParameter.QUERY,
-                            description='The initial index from which to return the results.',
-                        ),
-                   ],
-                   summary="Retrieve a list of eligible athletes for a specific event along with their seed times")
+        OpenApiParameter(
+            name='limit',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.QUERY,
+            description='Number of results to return per page.',
+        ),
+        OpenApiParameter(
+            name='offset',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.QUERY,
+            description='The initial index from which to return the results.',
+        ),
+    ],
+        summary="Retrieve a list of eligible athletes for a specific event along with their seed times")
     def get(self, request, event_id):
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Getting the group and event_type
+
+        # Getting the group and event_type
         group_id = event_instance.group.id
         event_type_id = event_instance.event_type.id
         date_of_swim_meet = event_instance.swim_meet.date
-        
-        #Checking that the event type exists
+
+        # Getting the meet id
+        meet_id = event_instance.swim_meet
+
+        # Checking that the event type exists
         try:
             event_type_instance = EventType.objects.get(id=event_type_id)
         except EventType.DoesNotExist:
             return Response({'error': 'Event type not found'}, status=status.HTTP_404_NOT_FOUND)
 
-        #On get_queryset we validate if the group exists and filter by group
-        athletes = self.get_queryset(group_id, date_of_swim_meet)
+        # On get_queryset we get the athletes enrolled in the swim meet and filtered by the group
+        athletes = self.get_queryset(meet_id, group_id, date_of_swim_meet)
         seed_times = []
 
         for athlete in athletes:
-            time_records = TimeRecord.objects.filter(athlete=athlete, event_type=event_type_instance).order_by('time')
+            time_records = TimeRecord.objects.filter(
+                athlete=athlete, event_type=event_type_instance).order_by('time')
             seed_time = time_records.first() or None
             if seed_time and seed_time.time < timedelta(days=200):
-                seed_times.append({'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': seed_time.time})
+                seed_times.append(
+                    {'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': seed_time.time})
             else:
                 # The serializer interpretes 200 days as NT (No time)
-                seed_times.append({'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': timedelta(days=200)})
+                seed_times.append(
+                    {'id': athlete.id, 'athlete_full_name': athlete.full_name, 'seed_time': timedelta(days=200)})
 
         serializer = AthleteSeedTimeSerializer(data=seed_times, many=True)
         serializer.is_valid(raise_exception=True)
@@ -75,14 +84,16 @@ class AthleteSeedTimeView(APIView):
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Checking that the event type exists
+
+        # Checking that the event type exists
         try:
-            event_type_instance = EventType.objects.get(id=event_instance.event_type.id)
+            event_type_instance = EventType.objects.get(
+                id=event_instance.event_type.id)
         except EventType.DoesNotExist:
             return Response({'error': 'Event type not found'}, status=status.HTTP_404_NOT_FOUND)
 
-        serializer = UpdateAthleteSeedTimeSerializer(data=request.data, context={'event_type':event_type_instance})
+        serializer = UpdateAthleteSeedTimeSerializer(
+            data=request.data, context={'event_type': event_type_instance})
         if serializer.is_valid(raise_exception=True):
             serializer.save()
             return Response({'success': 'Time registered.'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR address issue #231 

**Implementation**

1. `backend/api/views/AthleteSeedTimeView.py`
In the get method:
- Get the swim meet id from the event instance and pass it as parameter to the `get_queryset` method.

In the `get_queryset`:
- Update the query to get the athletes for which the seed times will be retrieved. Instead of getting all the athletes available, now we are filtering those who are enrolled in the given swim meet. 
- The `queryset` is filtered then by group (as it was before)

This change will allow the get method to return the seed time of the athletes currently enrolled in the swim meet.
