### PR TITLE
BE-AthleteSerializer modification

### DIFF
--- a/backend/api/serializers/AthleteSerializer.py
+++ b/backend/api/serializers/AthleteSerializer.py
@@ -18,11 +18,10 @@ class AthleteSerializer(serializers.ModelSerializer):
 
     def get_age(self, obj):
         """Calculate age from date_of_birth."""
-        if obj.date_of_birth:
-            today = timezone.now().date()
-            return today.year - obj.date_of_birth.year - (
-                (today.month, today.day) < (obj.date_of_birth.month, obj.date_of_birth.day)
-            )
+        today = timezone.now().date()
+        return today.year - obj.date_of_birth.year - (
+            (today.month, today.day) < (obj.date_of_birth.month, obj.date_of_birth.day)
+        )
 
 
     # Validate that the date is not in the future

--- a/backend/api/serializers/AthleteSerializer.py
+++ b/backend/api/serializers/AthleteSerializer.py
@@ -7,7 +7,7 @@ class AthleteSerializer(serializers.ModelSerializer):
     first_name = serializers.CharField(max_length=50)
     last_name = serializers.CharField(max_length=50)
     full_name = serializers.CharField(read_only=True)
-    age = serializers.IntegerField(read_only=True)
+    age = serializers.SerializerMethodField()
     gender_display = serializers.CharField(source='get_gender_display', read_only=True)
 
 
@@ -15,6 +15,15 @@ class AthleteSerializer(serializers.ModelSerializer):
         model = Athlete
         fields = '__all__'
         read_only_fields = ['full_name', 'age','gender_display']
+
+    def get_age(self, obj):
+        """Calculate age from date_of_birth."""
+        if obj.date_of_birth:
+            today = timezone.now().date()
+            return today.year - obj.date_of_birth.year - (
+                (today.month, today.day) < (obj.date_of_birth.month, obj.date_of_birth.day)
+            )
+
 
     # Validate that the date is not in the future
     def validate_date_of_birth(self, value):

--- a/backend/api/views/AthleteView.py
+++ b/backend/api/views/AthleteView.py
@@ -4,8 +4,6 @@ from rest_framework.permissions import IsAuthenticated
 from django.db.models.functions import Collate
 from api.models import Athlete
 from api.serializers.AthleteSerializer import AthleteSerializer
-from django.db.models import F, Func, IntegerField, Value
-from django.utils import timezone
 from api.CustomFilter import filter_by_group
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 import logging
@@ -20,24 +18,19 @@ class AthleteViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     filter_backends = [OrderingFilter, SearchFilter]
     http_method_names = ['get', 'post', 'delete', 'patch']
-    search_fields = ['^first_name_search','^last_name_search']
+    search_fields = ['^first_name_search', '^last_name_search']
     ordering = ['first_name']
-    
+
     def get_queryset(self):
         queryset = Athlete.objects.annotate(
-        first_name_search=Collate("first_name", "und-x-icu"),
-        last_name_search=Collate("last_name", "und-x-icu"),
-        age=Func(
-                Value("year"),
-                Func(Value(timezone.now().date()), F("date_of_birth"), function="age"),
-                function="date_part",
-                output_field=IntegerField()),
+            first_name_search=Collate("first_name", "und-x-icu"),
+            last_name_search=Collate("last_name", "und-x-icu"),
         )
         group_id = self.request.query_params.get('group_id')
         if group_id is not None:
             queryset = filter_by_group(group_id=group_id, queryset=queryset)
         return queryset
-    
-    @extend_schema(parameters =[OpenApiParameter(name="group_id", type=int),])
+
+    @extend_schema(parameters=[OpenApiParameter(name="group_id", type=int),])
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)


### PR DESCRIPTION
This PR addresses issue #261 

### Implementation

1. backend/api/views/AthleteView.py

- Removed the `age` annotation from the `get_queryset` method.
- Eliminated all related imports previously used for calculating `age`.

2. backend/api/serializers/AthleteSerializer.py

- `age` is a `SerializerMethodField` now.
- Implemented the `get_age` method:
   - Calculates the age by subtracting the athlete’s year of birth from the current year.
   - If the athlete’s birthday has not yet occurred this year (i.e., current month and day are earlier than the birth month and day), subtracts 1 from the result.

