### PR TITLE
BUG -No records message

### DIFF
--- a/frontend/src/Athlete/AthleteDisplay.jsx
+++ b/frontend/src/Athlete/AthleteDisplay.jsx
@@ -90,7 +90,6 @@ const AthleteDisplay = () => {
     lastCreatedAthleteId.current = null;
   };
 
-
   const handleEditClick = (row) => {
     if (searchBarRef.current) {
       searchBarRef.current.clearSearch();
@@ -107,7 +106,7 @@ const AthleteDisplay = () => {
       onClick: handleEditClick,
       tip: "Edit Athlete",
     },
-  ]; 
+  ];
 
   useEffect(() => {
     let ignore = false;
@@ -143,6 +142,11 @@ const AthleteDisplay = () => {
   let actionButtonsErrorOnLoading = [
     { label: "Reload", onClick: handleReload },
   ];
+
+  let messageNoRecords =
+    searchPar === ""
+      ? "No athletes have been added yet"
+      : "No athletes match your search";
 
   const renderContent = () => {
     if (errorOnLoading) {
@@ -201,6 +205,7 @@ const AthleteDisplay = () => {
                 data={athleteData}
                 columns={columns}
                 actions={actions}
+                notRecordsMessage={messageNoRecords}
               />
               <PaginationBar
                 count={count}

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -155,6 +155,11 @@ const SwimMeetDisplay = () => {
     { label: "Reload", onClick: handleReload },
   ];
 
+  let messageNoRecords =
+    searchPar === ""
+      ? "No swim meets have been scheduled yet"
+      : "No swim meets match your search";
+
   const renderContent = () => {
     if (errorOnLoading) {
       return (
@@ -206,7 +211,12 @@ const SwimMeetDisplay = () => {
         )}
         {!loading && (
           <>
-            <GenericTable data={data} columns={columns} actions={actions} />
+            <GenericTable
+              data={data}
+              columns={columns}
+              actions={actions}
+              notRecordsMessage={messageNoRecords}
+            />
             <PaginationBar
               count={count}
               setOffset={setOffset}

--- a/frontend/src/components/Common/GenericTable.jsx
+++ b/frontend/src/components/Common/GenericTable.jsx
@@ -2,9 +2,22 @@ import {
   MaterialReactTable,
   useMaterialReactTable,
 } from "material-react-table";
-import { Box, IconButton, Tooltip, useTheme } from "@mui/material";
+import {
+  Box,
+  IconButton,
+  Tooltip,
+  useTheme,
+  Typography,
+} from "@mui/material";
 
-const GenericTable = ({ data, columns, actions, notRecordsMessage, enableSearch, getRowStyle }) => {
+const GenericTable = ({
+  data,
+  columns,
+  actions,
+  notRecordsMessage,
+  enableSearch,
+  getRowStyle,
+}) => {
   const enableActions = actions;
   const theme = useTheme();
   const table = useMaterialReactTable({
@@ -22,16 +35,26 @@ const GenericTable = ({ data, columns, actions, notRecordsMessage, enableSearch,
     enableSorting: false,
     enableRowActions: enableActions,
     positionActionsColumn: "last",
-    initialState: { density: "compact", showGlobalFilter: enableSearch ? enableSearch : false },
+    initialState: {
+      density: "compact",
+      showGlobalFilter: enableSearch ? enableSearch : false,
+    },
     enableTopToolbar: enableSearch ? enableSearch : false,
     enableToolbarInternalActions: false,
     enableBottomToolbar: false,
     enableColumnActions: false,
     enablePagination: false,
-    localization: {
-      noRecordsToDisplay: notRecordsMessage,
+    renderEmptyRowsFallback: () => {
+      return (<Box sx={{ textAlign: "center", padding: 1 }}>
+      <Typography
+        variant={"h8"}
+        component="div"
+        sx={{ color: "text.secondary", fontStyle: "italic" }}
+      >
+        {notRecordsMessage}
+      </Typography>
+    </Box>)
     },
-
     renderRowActions: ({ row }) => (
       <Box>
         {actions &&


### PR DESCRIPTION
This PR addresses issue #264.
It can also be used to test PR #265 — make sure to merge #265 first, then this PR.


### Implementation

In the following files:

- frontend/src/Athlete/AthleteDisplay.jsx

- frontend/src/SwimMeet/SwimMeetDisplay.jsx

The following changes were made:

- Added a `messageNoRecords` variable that sets the appropriate message based on whether `searchPar` is empty or not, as outlined in issue #264.

- Passed `messageNoRecords` as the `noRecordsMessage` prop to the `GenericTable` component.


