### PR TITLE
BE-Modificate HeatBatchView to Validate Enrollment

### DIFF
--- a/backend/api/views/HeatView.py
+++ b/backend/api/views/HeatView.py
@@ -103,7 +103,7 @@ class HeatBatchView(APIView):
             enrolled_athlete_ids = set(
                 enrolled_athletes.values_list('id', flat=True))
             if not request_athlete_ids.issubset(enrolled_athlete_ids):
-                return Response({'error': 'One or more athletes are not enroll in the swim meet.'}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({'error': 'One or more athletes are not enrolled in the swim meet.'}, status=status.HTTP_400_BAD_REQUEST)
 
             # Validate group
             group_athletes = filter_by_group(

--- a/backend/api/views/HeatView.py
+++ b/backend/api/views/HeatView.py
@@ -7,8 +7,7 @@ from api.serializers.HeatDisplaySerializer import HeatSerializer
 from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema
 from django.db import transaction
-from django.db.models import F, Value, Func, IntegerField
-from django.utils import timezone
+from api.CustomFilter import filter_by_group
 
 
 @extend_schema(tags=['Heat'])
@@ -16,26 +15,27 @@ class HeatBatchView(APIView):
 
     @extend_schema(summary="Retrieves the lane assignments for each heat for a given event")
     def get(self, request, event_id):
-        #Get event instance
+        # Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get num_lanes
+
+        # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
         except:
             return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
-        
-        max_num_heat = event_instance.total_num_heats 
+
+        max_num_heat = event_instance.total_num_heats
 
         if max_num_heat:
             heats_data = []
-            for heat_num in range (1,max_num_heat+1):
+            for heat_num in range(1, max_num_heat+1):
                 # Retrieve all heats for the given event_id and heat_num
-                heats = Heat.objects.filter(event_id=event_id, num_heat=heat_num)
+                heats = Heat.objects.filter(
+                    event_id=event_id, num_heat=heat_num)
                 lanes_data = []
                 for lane_num in range(1, num_lanes + 1):
                     lane_data = heats.filter(lane_num=lane_num).first()
@@ -48,63 +48,74 @@ class HeatBatchView(APIView):
                             "athlete": None,
                             "seed_time": None,
                             "heat_time": None
-                    })
+                        })
                 serializer = HeatSerializer(lanes_data, many=True)
                 heats_data.append({
-                "id": heat_num,
-                "heat_name": f"Heat {heat_num}",
-                "lanes": serializer.data
-            })
+                    "id": heat_num,
+                    "heat_name": f"Heat {heat_num}",
+                    "lanes": serializer.data
+                })
             return Response({
-            "count": max_num_heat,
-            "results": heats_data
-        }, status=status.HTTP_200_OK)
+                "count": max_num_heat,
+                "results": heats_data
+            }, status=status.HTTP_200_OK)
         else:
             return Response({
-            "count": 0,
-            "results": []
-        }, status=status.HTTP_200_OK)
+                "count": 0,
+                "results": []
+            }, status=status.HTTP_200_OK)
 
-
-    @extend_schema(request=GenerateHeatSerializer, methods=['POST'],summary="Given an event and a list of participants with their seed times, generates the heats")
+    @extend_schema(request=GenerateHeatSerializer, methods=['POST'], summary="Given an event and a list of participants with their seed times, generates the heats")
     def post(self, request, event_id):
-        #Get event instance
+        # Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #The event should not have heats
+
+        # The event should not have heats
         if Heat.objects.filter(event=event_instance).exists():
             return Response({'error': 'Event already has heats'}, status=status.HTTP_400_BAD_REQUEST)
-       
-        #Get num_lanes
+
+        # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
+
         except:
             return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get group_id
+
+        # Get group_id
         try:
             group_instance = event_instance.group
         except:
             return Response({'error': 'Not able to retrieve group'}, status=status.HTTP_404_NOT_FOUND)
-        
-       
-        serializer = GenerateHeatSerializer(data=request.data, context={'num_lanes': num_lanes, 'event': event_instance})
+
+        serializer = GenerateHeatSerializer(data=request.data, context={
+                                            'num_lanes': num_lanes, 'event': event_instance})
         if serializer.is_valid(raise_exception=True):
-            #Before saving, check that the given athletes are part of the event group
             athletes_data = request.data.get('athletes', [])
-            queryset = self.get_queryset(group_instance.id)
-            queryset_athlete_ids = set(queryset.values_list('id', flat=True))
             request_athlete_ids = {athlete['id'] for athlete in athletes_data}
-            if not request_athlete_ids.issubset(queryset_athlete_ids):
+
+            # Validate enrollment
+            enrolled_athletes = Athlete.objects.filter(
+                athlete_swim_meets__swim_meet=swim_meet_instance.id)
+            enrolled_athlete_ids = set(
+                enrolled_athletes.values_list('id', flat=True))
+            if not request_athlete_ids.issubset(enrolled_athlete_ids):
+                return Response({'error': 'One or more athletes are not enroll in the swim meet.'}, status=status.HTTP_400_BAD_REQUEST)
+
+            # Validate group
+            group_athletes = filter_by_group(
+                group_id=group_instance.id, queryset=enrolled_athletes, date=swim_meet_instance.date, from_athlete_model=True)
+            group_athlete_ids = set(
+                group_athletes.values_list('id', flat=True))
+            if not request_athlete_ids.issubset(group_athlete_ids):
                 return Response({'error': 'One or more athletes are not part of the specified group for the event.'}, status=status.HTTP_400_BAD_REQUEST)
+
             serializer.save()
         return Response({'success': 'Heats generated'}, status=status.HTTP_200_OK)
-    
-    
+
     @extend_schema(summary="Deletes all the heats for a given event")
     @transaction.atomic
     def delete(self, request, event_id):
@@ -112,7 +123,7 @@ class HeatBatchView(APIView):
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
+
         try:
             Heat.objects.filter(event=event_instance).delete()
             event_instance.total_num_heats = 0
@@ -120,58 +131,34 @@ class HeatBatchView(APIView):
         except Exception as e:
             transaction.set_rollback(True)
             return Response({'error': f'Failed to delete heats: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        
+
         return Response({'success': 'Associated heats deleted'}, status=status.HTTP_200_OK)
 
-    def get_queryset(self, group_id):
-        try:
-            group_instance = Group.objects.get(id=group_id)
-        except Group.DoesNotExist:
-            raise ValidationError({'error': "Group does not exist"}, code=status.HTTP_400_BAD_REQUEST)
-        queryset = Athlete.objects.all()
-        queryset = queryset.annotate(
-                age=Func(
-                    Value("year"),
-                    Func(Value(timezone.now().date()), F(
-                        "date_of_birth"), function="age"),
-                    function="date_part",
-                    output_field=IntegerField()))
-        
-        gender = group_instance.gender
-        if gender != 'MX':
-            queryset = queryset.filter(gender=gender)
-        min_age = group_instance.min_age
-        max_age = group_instance.max_age
-        if max_age is not None:
-            queryset = queryset.filter(age__lte=max_age)
-        if min_age is not None:
-            queryset = queryset.filter(age__gte=min_age)
-            
-        return queryset
-    
+
 @extend_schema(tags=['Heat'])
 class HeatDetailView(APIView):
     @extend_schema(summary="Displays lanes distribution on a specific heat for a given event")
     def get(self, request, event_id, heat_num):
-        #Get event instance
+        # Get event instance
         try:
             event_instance = MeetEvent.objects.get(id=event_id)
         except MeetEvent.DoesNotExist:
             return Response({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get number of lanes on the event
+
+        # Get number of lanes on the event
         try:
             swim_meet_instance = event_instance.swim_meet
             num_lanes = swim_meet_instance.site.num_lanes
         except:
             return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
-        
-        #Get number of heats on the event
-        max_num_heat = event_instance.total_num_heats 
+
+        # Get number of heats on the event
+        max_num_heat = event_instance.total_num_heats
         if max_num_heat:
-            if 1<= heat_num <= max_num_heat:
+            if 1 <= heat_num <= max_num_heat:
                 # Retrieve all heats for the given event_id and heat_num
-                heats = Heat.objects.filter(event_id=event_id, num_heat=heat_num)
+                heats = Heat.objects.filter(
+                    event_id=event_id, num_heat=heat_num)
                 lanes_data = []
                 for lane_num in range(1, num_lanes + 1):
                     lane_data = heats.filter(lane_num=lane_num).first()
@@ -184,15 +171,15 @@ class HeatDetailView(APIView):
                             "athlete": None,
                             "seed_time": None,
                             "heat_time": None
-                    })
-        
+                        })
+
                 # Serialize the lanes_data using HeatSerializer
                 serializer = HeatSerializer(lanes_data, many=True)
                 response_data = {
                     'count': len(lanes_data),
                     'results': serializer.data
                 }
-        
+
                 return Response(response_data, status=status.HTTP_200_OK)
             else:
                 return Response({'error': 'There is not a heat with that number'}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This PR address issue #268 

### Implementation

On `HeatBatchView`:

- Removed the `get_queryset` method, as its logic is now integrated directly into the `post` method.
- After serializer validation in the `post` method, added explicit validation to ensure:
  - All athletes in the request are enrolled in the swim meet.
  - All athletes in the request are also members of the group associated with the event, based on enrollment and group filtering.