### PR TITLE
FE-Unenroll athletes

### DIFF
--- a/frontend/src/Enrollment/AddEnrollment.jsx
+++ b/frontend/src/Enrollment/AddEnrollment.jsx
@@ -1,0 +1,307 @@
+import {
+    ContentPaste as BackIcon,
+    Build as BuildIcon,
+    KeyboardDoubleArrowLeft as LeftAllIcon,
+    NavigateBefore as LeftIcon,
+    KeyboardDoubleArrowRight as RightAllIcon,
+    NavigateNext as RightIcon,
+  } from "@mui/icons-material";
+  import {
+    CircularProgress,
+    Box,
+    Dialog,
+    DialogContent,
+    Stack,
+  } from "@mui/material";
+  import React, { useEffect, useState } from "react";
+  import "../App.css";
+  import { SmmApi } from "../SmmApi.jsx";
+  import AlertBox from "../components/Common/AlertBox.jsx";
+  import SelectTable from "../components/Common/SelectTable.jsx";
+  import MyIconButton from "../components/FormElements/MyIconButton.jsx";
+  import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
+  
+  // Constants for table columns
+  const availableColumns = [
+    {
+      accessorKey: "full_name",
+      header: "Available Athletes",
+      size: 150,
+    },
+  ];
+  
+  const selectedColumns = [
+    {
+      accessorKey: "full_name",
+      header: "Selected Athletes",
+      size: 150,
+    },
+  ];
+  
+  const AddEnrollment = ({ meetId, onBack, onProcessCompletion }) => {
+    //States to manage table data
+    const [availableAthletes, setAvailableAthletes] = useState([]);
+    const [selectedAthletes, setSelectedAthletes] = useState([]);
+    const [selectedRightAthletes, setSelectedRightAthletes] = useState({});
+    const [selectedLeftAthletes, setSelectedLeftAthletes] = useState({});
+    //State to manage loading
+    const [loading, setLoading] = useState(false);
+    const [errorOnLoading, setErrorOnLoading] = useState(false);
+    //State to manage search on selectTables
+    const [availableSearchTerm, setAvailableSearchTerm] = useState("");
+    const [selectedSearchTerm, setSelectedSearchTerm] = useState("");
+    //State to manage Enrollment Creation
+    const [enrollmentCreated, setEnrollmentCreated] = useState(false);
+    const [errorCreateEnrollment, setErrorCreateEnrollment] = useState(false);
+  
+    // AlertBox variables
+    let typeAlertCreateEnrollment = errorCreateEnrollment ? "error" : "success";
+    let messageCreateEnrollment = errorCreateEnrollment
+      ? errorCreateEnrollment
+      : "Enrollment created successfully!";
+  
+    useEffect(() => {
+      let ignore = false;
+      async function fetching() {
+        setLoading(true);
+        setErrorOnLoading(false);
+        try {
+          const athletes_json = await SmmApi.getUnenrolledAthletes(meetId);
+          if (!ignore) {
+            setAvailableAthletes(athletes_json);
+          }
+        } catch (error) {
+          setErrorOnLoading(true);
+        } finally {
+          setLoading(false);
+        }
+      }
+      fetching();
+      return () => {
+        ignore = true;
+      };
+    }, []);
+  
+    //Event Handlers
+  
+    const handleAddEnrollment = async (selectedAthletes) => {
+      setErrorCreateEnrollment(false);
+      let enrollmentCreationSuccessful = false;
+      try {
+        const athleteIds = selectedAthletes.map((athlete) => athlete.id);
+        const response = await SmmApi.createEnrollment(meetId, {
+          athlete_ids: athleteIds,
+        });
+        enrollmentCreationSuccessful = true;
+      } catch (error) {
+        setErrorCreateEnrollment(
+          "Unable to complete the enrollment, an unexpected error occurred. Please try again!"
+        );
+      }
+      setEnrollmentCreated(true);
+      setTimeout(() => {
+        if (enrollmentCreationSuccessful) {
+          onBack();
+        }
+        setEnrollmentCreated(false);
+      }, 2000);
+    };
+  
+    const extraButtons = [
+      {
+        label: "Confirm Enrollment",
+        icon: <BuildIcon />,
+        onClick: () => handleAddEnrollment(selectedAthletes),
+        disabled: selectedAthletes.length === 0,
+      },
+      {
+        label: "Back to Enrollment",
+        icon: <BackIcon />,
+        onClick: onBack,
+      },
+    ];
+  
+    const handleClearSearch = () => {
+      setAvailableSearchTerm("");
+      setSelectedSearchTerm("");
+    };
+  
+    const onRightSelected = () => {
+      handleClearSearch();
+      const athletesToMove = availableAthletes.filter(
+        (item) => item.id in selectedRightAthletes
+      );
+      setSelectedAthletes((prevSelectedAthletes) => {
+        const updatedAthletes = [...prevSelectedAthletes, ...athletesToMove];
+        return updatedAthletes.sort((a, b) =>
+          a.full_name.localeCompare(b.full_name)
+        );
+      });
+      setAvailableAthletes((prevAvailableAthletes) =>
+        prevAvailableAthletes.filter(
+          (item) => !(item.id in selectedRightAthletes)
+        )
+      );
+      setSelectedRightAthletes({});
+    };
+  
+    const onRightAll = () => {
+      handleClearSearch();
+      setSelectedAthletes((prevSelectedAthletes) => {
+        const allAthletes = [...prevSelectedAthletes, ...availableAthletes];
+        return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
+      });
+      setAvailableAthletes([]);
+      setSelectedLeftAthletes({});
+      setSelectedRightAthletes({});
+    };
+  
+    const onLeftAll = () => {
+      handleClearSearch();
+      setAvailableAthletes((prevAvailableAthletes) => {
+        const allAthletes = [...prevAvailableAthletes, ...selectedAthletes];
+        return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
+      });
+      setSelectedAthletes([]);
+      setSelectedLeftAthletes({});
+      setSelectedRightAthletes({});
+    };
+  
+    const onLeftSelected = () => {
+      handleClearSearch();
+      const athletesToMove = selectedAthletes.filter(
+        (item) => item.id in selectedLeftAthletes
+      );
+      setAvailableAthletes((prevAvailableAthletes) => {
+        const updatedAthletes = [...prevAvailableAthletes, ...athletesToMove];
+        return updatedAthletes.sort((a, b) =>
+          a.full_name.localeCompare(b.full_name)
+        );
+      });
+      setSelectedAthletes((prevSelectedAthletes) =>
+        prevSelectedAthletes.filter((item) => !(item.id in selectedLeftAthletes))
+      );
+      setSelectedLeftAthletes({});
+    };
+  
+    const renderContent = () => {
+      if (loading) {
+        return (
+          <Stack
+            alignItems="center"
+            justifyContent="center"
+            style={{ height: "100px" }}
+          >
+            <CircularProgress />
+          </Stack>
+        );
+      }
+  
+      if (errorOnLoading) {
+        return (
+          <Stack
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+              width: "300px",
+              margin: "auto",
+            }}
+          >
+            <AlertBox
+              type="error"
+              message="We were unable to load the required data. Please try again."
+            />
+          </Stack>
+        );
+      }
+      return (
+        <>
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            sx={{ gap: "25px", width: "100%", height: "auto", margin: "2px" }}
+          >
+            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+              <SelectTable
+                data={availableAthletes}
+                columns={availableColumns}
+                selection={selectedRightAthletes}
+                rowSelection={selectedRightAthletes}
+                setRowSelection={setSelectedRightAthletes}
+                notRecordsMessage={"No athletes available."}
+                searchTerm={availableSearchTerm}
+                setSearchTerm={setAvailableSearchTerm}
+                labels={["Athletes Available", "Athlete"]}
+              />
+            </Box>
+  
+            <Box display="flex" flexDirection="column" alignItems="center">
+              <MyIconButton
+                onClick={onRightSelected}
+                disabled={Object.keys(selectedRightAthletes).length === 0}
+              >
+                <RightIcon />
+              </MyIconButton>
+  
+              <MyIconButton
+                onClick={onRightAll}
+                disabled={availableAthletes.length === 0}
+              >
+                <RightAllIcon />
+              </MyIconButton>
+  
+              <MyIconButton
+                onClick={onLeftAll}
+                disabled={selectedAthletes.length === 0}
+              >
+                <LeftAllIcon />
+              </MyIconButton>
+  
+              <MyIconButton
+                onClick={onLeftSelected}
+                disabled={Object.keys(selectedLeftAthletes).length === 0}
+              >
+                <LeftIcon />
+              </MyIconButton>
+            </Box>
+  
+            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+              <SelectTable
+                data={selectedAthletes}
+                columns={selectedColumns}
+                rowSelection={selectedLeftAthletes}
+                setRowSelection={setSelectedLeftAthletes}
+                notRecordsMessage={"No athletes selected."}
+                searchTerm={selectedSearchTerm}
+                setSearchTerm={setSelectedSearchTerm}
+                labels={["Athletes Selected", "Athlete"]}
+              />
+            </Box>
+          </Box>
+          <Dialog open={enrollmentCreated} fullWidth>
+            <DialogContent style={{ padding: "24px" }}>
+              <AlertBox
+                type={typeAlertCreateEnrollment}
+                message={messageCreateEnrollment}
+              />
+            </DialogContent>
+          </Dialog>
+        </>
+      );
+    };
+  
+    return (
+      <div>
+        <ItemPaginationBar
+          label={""}
+          extraActions={extraButtons}
+          enableNavigationButtons={false}
+        ></ItemPaginationBar>
+        {renderContent()}
+      </div>
+    );
+  };
+  
+  export default AddEnrollment;

--- a/frontend/src/Enrollment/AddEnrollment.jsx
+++ b/frontend/src/Enrollment/AddEnrollment.jsx
@@ -1,307 +1,313 @@
 import {
-    ContentPaste as BackIcon,
-    Build as BuildIcon,
-    KeyboardDoubleArrowLeft as LeftAllIcon,
-    NavigateBefore as LeftIcon,
-    KeyboardDoubleArrowRight as RightAllIcon,
-    NavigateNext as RightIcon,
-  } from "@mui/icons-material";
-  import {
-    CircularProgress,
-    Box,
-    Dialog,
-    DialogContent,
-    Stack,
-  } from "@mui/material";
-  import React, { useEffect, useState } from "react";
-  import "../App.css";
-  import { SmmApi } from "../SmmApi.jsx";
-  import AlertBox from "../components/Common/AlertBox.jsx";
-  import SelectTable from "../components/Common/SelectTable.jsx";
-  import MyIconButton from "../components/FormElements/MyIconButton.jsx";
-  import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
-  
-  // Constants for table columns
-  const availableColumns = [
-    {
-      accessorKey: "full_name",
-      header: "Available Athletes",
-      size: 150,
-    },
-  ];
-  
-  const selectedColumns = [
-    {
-      accessorKey: "full_name",
-      header: "Selected Athletes",
-      size: 150,
-    },
-  ];
-  
-  const AddEnrollment = ({ meetId, onBack, onProcessCompletion }) => {
-    //States to manage table data
-    const [availableAthletes, setAvailableAthletes] = useState([]);
-    const [selectedAthletes, setSelectedAthletes] = useState([]);
-    const [selectedRightAthletes, setSelectedRightAthletes] = useState({});
-    const [selectedLeftAthletes, setSelectedLeftAthletes] = useState({});
-    //State to manage loading
-    const [loading, setLoading] = useState(false);
-    const [errorOnLoading, setErrorOnLoading] = useState(false);
-    //State to manage search on selectTables
-    const [availableSearchTerm, setAvailableSearchTerm] = useState("");
-    const [selectedSearchTerm, setSelectedSearchTerm] = useState("");
-    //State to manage Enrollment Creation
-    const [enrollmentCreated, setEnrollmentCreated] = useState(false);
-    const [errorCreateEnrollment, setErrorCreateEnrollment] = useState(false);
-  
-    // AlertBox variables
-    let typeAlertCreateEnrollment = errorCreateEnrollment ? "error" : "success";
-    let messageCreateEnrollment = errorCreateEnrollment
-      ? errorCreateEnrollment
-      : "Enrollment created successfully!";
-  
-    useEffect(() => {
-      let ignore = false;
-      async function fetching() {
-        setLoading(true);
-        setErrorOnLoading(false);
-        try {
-          const athletes_json = await SmmApi.getUnenrolledAthletes(meetId);
-          if (!ignore) {
-            setAvailableAthletes(athletes_json);
-          }
-        } catch (error) {
-          setErrorOnLoading(true);
-        } finally {
-          setLoading(false);
-        }
-      }
-      fetching();
-      return () => {
-        ignore = true;
-      };
-    }, []);
-  
-    //Event Handlers
-  
-    const handleAddEnrollment = async (selectedAthletes) => {
-      setErrorCreateEnrollment(false);
-      let enrollmentCreationSuccessful = false;
+  ContentPaste as BackIcon,
+  Build as BuildIcon,
+  KeyboardDoubleArrowLeft as LeftAllIcon,
+  NavigateBefore as LeftIcon,
+  KeyboardDoubleArrowRight as RightAllIcon,
+  NavigateNext as RightIcon,
+} from "@mui/icons-material";
+import {
+  CircularProgress,
+  Box,
+  Dialog,
+  DialogContent,
+  Stack,
+} from "@mui/material";
+import React, { useEffect, useState } from "react";
+import "../App.css";
+import { SmmApi } from "../SmmApi.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import SelectTable from "../components/Common/SelectTable.jsx";
+import MyIconButton from "../components/FormElements/MyIconButton.jsx";
+import ItemPaginationBar from "../components/Common/ItemPaginationBar.jsx";
+
+// Constants for table columns
+const availableColumns = [
+  {
+    accessorKey: "full_name",
+    header: "Available Athletes",
+    size: 150,
+  },
+];
+
+const selectedColumns = [
+  {
+    accessorKey: "full_name",
+    header: "Selected Athletes",
+    size: 150,
+  },
+];
+
+const AddEnrollment = ({ meetId, onBack, onProcessCompletion }) => {
+  //States to manage table data
+  const [availableAthletes, setAvailableAthletes] = useState([]);
+  const [selectedAthletes, setSelectedAthletes] = useState([]);
+  const [selectedRightAthletes, setSelectedRightAthletes] = useState({});
+  const [selectedLeftAthletes, setSelectedLeftAthletes] = useState({});
+  //State to manage loading
+  const [loading, setLoading] = useState(false);
+  const [errorOnLoading, setErrorOnLoading] = useState(false);
+  //State to manage search on selectTables
+  const [availableSearchTerm, setAvailableSearchTerm] = useState("");
+  const [selectedSearchTerm, setSelectedSearchTerm] = useState("");
+  //State to manage Enrollment Creation
+  const [enrollmentCreated, setEnrollmentCreated] = useState(false);
+  const [errorCreateEnrollment, setErrorCreateEnrollment] = useState(false);
+
+  // AlertBox variables
+  let typeAlertCreateEnrollment =
+    errorCreateEnrollment ===
+    "Unable to complete the enrollment, an unexpected error occurred. Please try again!"
+      ? "error"
+      : "success";
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetching() {
+      setLoading(true);
+      setErrorOnLoading(false);
       try {
-        const athleteIds = selectedAthletes.map((athlete) => athlete.id);
-        const response = await SmmApi.createEnrollment(meetId, {
-          athlete_ids: athleteIds,
-        });
-        enrollmentCreationSuccessful = true;
-      } catch (error) {
-        setErrorCreateEnrollment(
-          "Unable to complete the enrollment, an unexpected error occurred. Please try again!"
-        );
-      }
-      setEnrollmentCreated(true);
-      setTimeout(() => {
-        if (enrollmentCreationSuccessful) {
-          onBack();
+        const athletes_json = await SmmApi.getUnenrolledAthletes(meetId);
+        if (!ignore) {
+          setAvailableAthletes(athletes_json);
         }
-        setEnrollmentCreated(false);
-      }, 2000);
-    };
-  
-    const extraButtons = [
-      {
-        label: "Confirm Enrollment",
-        icon: <BuildIcon />,
-        onClick: () => handleAddEnrollment(selectedAthletes),
-        disabled: selectedAthletes.length === 0,
-      },
-      {
-        label: "Back to Enrollment",
-        icon: <BackIcon />,
-        onClick: onBack,
-      },
-    ];
-  
-    const handleClearSearch = () => {
-      setAvailableSearchTerm("");
-      setSelectedSearchTerm("");
-    };
-  
-    const onRightSelected = () => {
-      handleClearSearch();
-      const athletesToMove = availableAthletes.filter(
-        (item) => item.id in selectedRightAthletes
-      );
-      setSelectedAthletes((prevSelectedAthletes) => {
-        const updatedAthletes = [...prevSelectedAthletes, ...athletesToMove];
-        return updatedAthletes.sort((a, b) =>
-          a.full_name.localeCompare(b.full_name)
-        );
-      });
-      setAvailableAthletes((prevAvailableAthletes) =>
-        prevAvailableAthletes.filter(
-          (item) => !(item.id in selectedRightAthletes)
-        )
-      );
-      setSelectedRightAthletes({});
-    };
-  
-    const onRightAll = () => {
-      handleClearSearch();
-      setSelectedAthletes((prevSelectedAthletes) => {
-        const allAthletes = [...prevSelectedAthletes, ...availableAthletes];
-        return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
-      });
-      setAvailableAthletes([]);
-      setSelectedLeftAthletes({});
-      setSelectedRightAthletes({});
-    };
-  
-    const onLeftAll = () => {
-      handleClearSearch();
-      setAvailableAthletes((prevAvailableAthletes) => {
-        const allAthletes = [...prevAvailableAthletes, ...selectedAthletes];
-        return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
-      });
-      setSelectedAthletes([]);
-      setSelectedLeftAthletes({});
-      setSelectedRightAthletes({});
-    };
-  
-    const onLeftSelected = () => {
-      handleClearSearch();
-      const athletesToMove = selectedAthletes.filter(
-        (item) => item.id in selectedLeftAthletes
-      );
-      setAvailableAthletes((prevAvailableAthletes) => {
-        const updatedAthletes = [...prevAvailableAthletes, ...athletesToMove];
-        return updatedAthletes.sort((a, b) =>
-          a.full_name.localeCompare(b.full_name)
-        );
-      });
-      setSelectedAthletes((prevSelectedAthletes) =>
-        prevSelectedAthletes.filter((item) => !(item.id in selectedLeftAthletes))
-      );
-      setSelectedLeftAthletes({});
-    };
-  
-    const renderContent = () => {
-      if (loading) {
-        return (
-          <Stack
-            alignItems="center"
-            justifyContent="center"
-            style={{ height: "100px" }}
-          >
-            <CircularProgress />
-          </Stack>
-        );
+      } catch (error) {
+        setErrorOnLoading(true);
+      } finally {
+        setLoading(false);
       }
-  
-      if (errorOnLoading) {
-        return (
-          <Stack
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "16px",
-              width: "300px",
-              margin: "auto",
-            }}
-          >
-            <AlertBox
-              type="error"
-              message="We were unable to load the required data. Please try again."
-            />
-          </Stack>
-        );
+    }
+    fetching();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  //Event Handlers
+
+  const handleAddEnrollment = async (selectedAthletes) => {
+    setErrorCreateEnrollment("");
+    let enrollmentCreationSuccessful = false;
+    try {
+      const athleteIds = selectedAthletes.map((athlete) => athlete.id);
+      const response = await SmmApi.createEnrollment(meetId, {
+        athlete_ids: athleteIds,
+      });
+      const num_added= athleteIds.length;
+      const athleteNoun = num_added === 1 ? "athlete": "athletes";
+      setErrorCreateEnrollment(
+        `Successfully enrolled ${num_added} ${athleteNoun} in the swim meet.`
+      );
+      enrollmentCreationSuccessful = true;
+    } catch (error) {
+      setErrorCreateEnrollment(
+        "Unable to complete the enrollment, an unexpected error occurred. Please try again!"
+      );
+    }
+    setEnrollmentCreated(true);
+    setTimeout(() => {
+      if (enrollmentCreationSuccessful) {
+        onBack();
       }
+      setEnrollmentCreated(false);
+    }, 2000);
+  };
+
+  const extraButtons = [
+    {
+      label: "Confirm Enrollment",
+      icon: <BuildIcon />,
+      onClick: () => handleAddEnrollment(selectedAthletes),
+      disabled: selectedAthletes.length === 0,
+    },
+    {
+      label: "Back to Enrollment",
+      icon: <BackIcon />,
+      onClick: onBack,
+    },
+  ];
+
+  const handleClearSearch = () => {
+    setAvailableSearchTerm("");
+    setSelectedSearchTerm("");
+  };
+
+  const onRightSelected = () => {
+    handleClearSearch();
+    const athletesToMove = availableAthletes.filter(
+      (item) => item.id in selectedRightAthletes
+    );
+    setSelectedAthletes((prevSelectedAthletes) => {
+      const updatedAthletes = [...prevSelectedAthletes, ...athletesToMove];
+      return updatedAthletes.sort((a, b) =>
+        a.full_name.localeCompare(b.full_name)
+      );
+    });
+    setAvailableAthletes((prevAvailableAthletes) =>
+      prevAvailableAthletes.filter(
+        (item) => !(item.id in selectedRightAthletes)
+      )
+    );
+    setSelectedRightAthletes({});
+  };
+
+  const onRightAll = () => {
+    handleClearSearch();
+    setSelectedAthletes((prevSelectedAthletes) => {
+      const allAthletes = [...prevSelectedAthletes, ...availableAthletes];
+      return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
+    });
+    setAvailableAthletes([]);
+    setSelectedLeftAthletes({});
+    setSelectedRightAthletes({});
+  };
+
+  const onLeftAll = () => {
+    handleClearSearch();
+    setAvailableAthletes((prevAvailableAthletes) => {
+      const allAthletes = [...prevAvailableAthletes, ...selectedAthletes];
+      return allAthletes.sort((a, b) => a.full_name.localeCompare(b.full_name));
+    });
+    setSelectedAthletes([]);
+    setSelectedLeftAthletes({});
+    setSelectedRightAthletes({});
+  };
+
+  const onLeftSelected = () => {
+    handleClearSearch();
+    const athletesToMove = selectedAthletes.filter(
+      (item) => item.id in selectedLeftAthletes
+    );
+    setAvailableAthletes((prevAvailableAthletes) => {
+      const updatedAthletes = [...prevAvailableAthletes, ...athletesToMove];
+      return updatedAthletes.sort((a, b) =>
+        a.full_name.localeCompare(b.full_name)
+      );
+    });
+    setSelectedAthletes((prevSelectedAthletes) =>
+      prevSelectedAthletes.filter((item) => !(item.id in selectedLeftAthletes))
+    );
+    setSelectedLeftAthletes({});
+  };
+
+  const renderContent = () => {
+    if (loading) {
       return (
-        <>
-          <Box
-            display="flex"
-            justifyContent="center"
-            alignItems="center"
-            sx={{ gap: "25px", width: "100%", height: "auto", margin: "2px" }}
-          >
-            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
-              <SelectTable
-                data={availableAthletes}
-                columns={availableColumns}
-                selection={selectedRightAthletes}
-                rowSelection={selectedRightAthletes}
-                setRowSelection={setSelectedRightAthletes}
-                notRecordsMessage={"No athletes available."}
-                searchTerm={availableSearchTerm}
-                setSearchTerm={setAvailableSearchTerm}
-                labels={["Athletes Available", "Athlete"]}
-              />
-            </Box>
-  
-            <Box display="flex" flexDirection="column" alignItems="center">
-              <MyIconButton
-                onClick={onRightSelected}
-                disabled={Object.keys(selectedRightAthletes).length === 0}
-              >
-                <RightIcon />
-              </MyIconButton>
-  
-              <MyIconButton
-                onClick={onRightAll}
-                disabled={availableAthletes.length === 0}
-              >
-                <RightAllIcon />
-              </MyIconButton>
-  
-              <MyIconButton
-                onClick={onLeftAll}
-                disabled={selectedAthletes.length === 0}
-              >
-                <LeftAllIcon />
-              </MyIconButton>
-  
-              <MyIconButton
-                onClick={onLeftSelected}
-                disabled={Object.keys(selectedLeftAthletes).length === 0}
-              >
-                <LeftIcon />
-              </MyIconButton>
-            </Box>
-  
-            <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
-              <SelectTable
-                data={selectedAthletes}
-                columns={selectedColumns}
-                rowSelection={selectedLeftAthletes}
-                setRowSelection={setSelectedLeftAthletes}
-                notRecordsMessage={"No athletes selected."}
-                searchTerm={selectedSearchTerm}
-                setSearchTerm={setSelectedSearchTerm}
-                labels={["Athletes Selected", "Athlete"]}
-              />
-            </Box>
-          </Box>
-          <Dialog open={enrollmentCreated} fullWidth>
-            <DialogContent style={{ padding: "24px" }}>
-              <AlertBox
-                type={typeAlertCreateEnrollment}
-                message={messageCreateEnrollment}
-              />
-            </DialogContent>
-          </Dialog>
-        </>
+        <Stack
+          alignItems="center"
+          justifyContent="center"
+          style={{ height: "100px" }}
+        >
+          <CircularProgress />
+        </Stack>
       );
-    };
-  
+    }
+
+    if (errorOnLoading) {
+      return (
+        <Stack
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            width: "300px",
+            margin: "auto",
+          }}
+        >
+          <AlertBox
+            type="error"
+            message="We were unable to load the required data. Please try again."
+          />
+        </Stack>
+      );
+    }
     return (
-      <div>
-        <ItemPaginationBar
-          label={""}
-          extraActions={extraButtons}
-          enableNavigationButtons={false}
-        ></ItemPaginationBar>
-        {renderContent()}
-      </div>
+      <>
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          sx={{ gap: "25px", width: "100%", height: "auto", margin: "2px" }}
+        >
+          <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+            <SelectTable
+              data={availableAthletes}
+              columns={availableColumns}
+              selection={selectedRightAthletes}
+              rowSelection={selectedRightAthletes}
+              setRowSelection={setSelectedRightAthletes}
+              notRecordsMessage={"No athletes available."}
+              searchTerm={availableSearchTerm}
+              setSearchTerm={setAvailableSearchTerm}
+              labels={["Athletes Available", "Athlete"]}
+            />
+          </Box>
+
+          <Box display="flex" flexDirection="column" alignItems="center">
+            <MyIconButton
+              onClick={onRightSelected}
+              disabled={Object.keys(selectedRightAthletes).length === 0}
+            >
+              <RightIcon />
+            </MyIconButton>
+
+            <MyIconButton
+              onClick={onRightAll}
+              disabled={availableAthletes.length === 0}
+            >
+              <RightAllIcon />
+            </MyIconButton>
+
+            <MyIconButton
+              onClick={onLeftAll}
+              disabled={selectedAthletes.length === 0}
+            >
+              <LeftAllIcon />
+            </MyIconButton>
+
+            <MyIconButton
+              onClick={onLeftSelected}
+              disabled={Object.keys(selectedLeftAthletes).length === 0}
+            >
+              <LeftIcon />
+            </MyIconButton>
+          </Box>
+
+          <Box flex="1" sx={{ maxWidth: "45%", flexGrow: 1 }}>
+            <SelectTable
+              data={selectedAthletes}
+              columns={selectedColumns}
+              rowSelection={selectedLeftAthletes}
+              setRowSelection={setSelectedLeftAthletes}
+              notRecordsMessage={"No athletes selected."}
+              searchTerm={selectedSearchTerm}
+              setSearchTerm={setSelectedSearchTerm}
+              labels={["Athletes Selected", "Athlete"]}
+            />
+          </Box>
+        </Box>
+        <Dialog open={enrollmentCreated} fullWidth>
+          <DialogContent style={{ padding: "24px" }}>
+            <AlertBox
+              type={typeAlertCreateEnrollment}
+              message={errorCreateEnrollment}
+            />
+          </DialogContent>
+        </Dialog>
+      </>
     );
   };
-  
-  export default AddEnrollment;
+
+  return (
+    <div>
+      <ItemPaginationBar
+        label={""}
+        extraActions={extraButtons}
+        enableNavigationButtons={false}
+      ></ItemPaginationBar>
+      {renderContent()}
+    </div>
+  );
+};
+
+export default AddEnrollment;

--- a/frontend/src/Enrollment/AddEnrollment.jsx
+++ b/frontend/src/Enrollment/AddEnrollment.jsx
@@ -38,7 +38,7 @@ const selectedColumns = [
   },
 ];
 
-const AddEnrollment = ({ meetId, onBack, onProcessCompletion }) => {
+const AddEnrollment = ({ meetId, onBack, setChangeEnrollment }) => {
   //States to manage table data
   const [availableAthletes, setAvailableAthletes] = useState([]);
   const [selectedAthletes, setSelectedAthletes] = useState([]);
@@ -99,6 +99,7 @@ const AddEnrollment = ({ meetId, onBack, onProcessCompletion }) => {
         `Successfully enrolled ${num_added} ${athleteNoun} in the swim meet.`
       );
       enrollmentCreationSuccessful = true;
+      setChangeEnrollment(true);
     } catch (error) {
       setErrorCreateEnrollment(
         "Unable to complete the enrollment, an unexpected error occurred. Please try again!"

--- a/frontend/src/Enrollment/EnrollmentDisplay.jsx
+++ b/frontend/src/Enrollment/EnrollmentDisplay.jsx
@@ -13,6 +13,7 @@ import AddEnrollment from "./AddEnrollment.jsx";
 import { CircularProgress, Box, Stack, Dialog } from "@mui/material";
 import { useEffect, useState, useRef } from "react";
 import { useLocation, useParams } from "react-router-dom";
+import Unenroll from "./Unenroll.jsx";
 
 const columns = [
   {
@@ -42,6 +43,8 @@ const EnrollmentDisplay = () => {
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isUnenrollOpen, setIsUnenrollOpen] = useState(false);
+  const [athleteToUnenroll, setAthleteToUnenroll] = useState("");
 
   //Use to control the search parameter
   const [searchPar, setSearchPar] = useState("");
@@ -55,12 +58,30 @@ const EnrollmentDisplay = () => {
   const [limit, setLimit] = useState(10);
   const [page, setPage] = useState(0); //search bar needs to restart this
 
-  const handleUnEnrollmentClick = (id) => {
-    console.log("Unenroll", id);
+  const handleUnenrollmentClick = (row) => {
+    console.log(enrollmentData[row]);
+    setAthleteToUnenroll(enrollmentData[row]);
+    setIsUnenrollOpen(true);
   };
 
   const handleAddEnrollment = () => {
     setIsFormOpen(true);
+  };
+
+  const handleCancelUnenrollment = () => {
+    if (changeEnrollment.current) {
+      if (searchPar !== "") {
+        if (searchBarRef.current) {
+          searchBarRef.current.clearSearch();
+        }
+        setSearchPar("");
+      } else {
+        setReloadEnrollmentDataTrigger((prev) => prev + 1);
+      }
+      changeEnrollment.current = false;
+    }
+    setAthleteToUnenroll("");
+    setIsUnenrollOpen(false);
   };
 
   const handleBackToEnrollment = () => {
@@ -110,7 +131,7 @@ const EnrollmentDisplay = () => {
     {
       name: "Unenroll",
       icon: <UnenrollIcon />,
-      onClick: handleUnEnrollmentClick,
+      onClick: handleUnenrollmentClick,
       tip: "Unenroll Athlete",
     },
   ];
@@ -200,6 +221,24 @@ const EnrollmentDisplay = () => {
               <AddEnrollment
                 meetId={meetId}
                 onBack={handleBackToEnrollment}
+                setChangeEnrollment={(value) =>
+                  (changeEnrollment.current = value)
+                }
+              />
+            </Dialog>
+            <Dialog
+              open={isUnenrollOpen}
+              fullWidth
+              PaperProps={{
+                sx: {
+                  overflowY: "hidden",
+                },
+              }}
+            >
+              <Unenroll
+                athlete={athleteToUnenroll}
+                meetId={meetId}
+                onBack={handleCancelUnenrollment}
                 setChangeEnrollment={(value) =>
                   (changeEnrollment.current = value)
                 }

--- a/frontend/src/Enrollment/EnrollmentDisplay.jsx
+++ b/frontend/src/Enrollment/EnrollmentDisplay.jsx
@@ -45,7 +45,6 @@ const EnrollmentDisplay = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isUnenrollOpen, setIsUnenrollOpen] = useState(false);
   const [athleteToUnenroll, setAthleteToUnenroll] = useState("");
-
   //Use to control the search parameter
   const [searchPar, setSearchPar] = useState("");
   const searchBarRef = useRef(null);
@@ -59,7 +58,6 @@ const EnrollmentDisplay = () => {
   const [page, setPage] = useState(0); //search bar needs to restart this
 
   const handleUnenrollmentClick = (row) => {
-    console.log(enrollmentData[row]);
     setAthleteToUnenroll(enrollmentData[row]);
     setIsUnenrollOpen(true);
   };

--- a/frontend/src/Enrollment/EnrollmentDisplay.jsx
+++ b/frontend/src/Enrollment/EnrollmentDisplay.jsx
@@ -11,7 +11,7 @@ import Title from "../components/Common/Title";
 import PaginationBar from "../components/Common/PaginationBar.jsx";
 import AddEnrollment from "./AddEnrollment.jsx";
 import { CircularProgress, Box, Stack, Dialog } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useLocation, useParams } from "react-router-dom";
 
 const columns = [
@@ -45,8 +45,10 @@ const EnrollmentDisplay = () => {
 
   //Use to control the search parameter
   const [searchPar, setSearchPar] = useState("");
+  const searchBarRef = useRef(null);
   const [reloadEnrollmentDataTrigger, setReloadEnrollmentDataTrigger] =
     useState(0);
+  const changeEnrollment = useRef(false);
   //Variables needed for the pagination bar
   const [count, setCount] = useState(0);
   const [offset, setOffset] = useState(0); //search bar needs to restart this
@@ -62,7 +64,17 @@ const EnrollmentDisplay = () => {
   };
 
   const handleBackToEnrollment = () => {
-    setReloadEnrollmentDataTrigger((prev) => prev + 1);
+    if (changeEnrollment.current) {
+      if (searchPar !== "") {
+        if (searchBarRef.current) {
+          searchBarRef.current.clearSearch();
+        }
+        setSearchPar("");
+      } else {
+        setReloadEnrollmentDataTrigger((prev) => prev + 1);
+      }
+      changeEnrollment.current = false;
+    }
     setIsFormOpen(false);
   };
 
@@ -141,6 +153,7 @@ const EnrollmentDisplay = () => {
           </Box>
           <Box className={"searchBox"} sx={{ marginRight: 5 }}>
             <SearchBar
+              ref={searchBarRef}
               setSearchPar={setSearchPar}
               setOffset={setOffset}
               setPage={setPage}
@@ -184,7 +197,13 @@ const EnrollmentDisplay = () => {
                 },
               }}
             >
-              <AddEnrollment meetId={meetId} onBack={handleBackToEnrollment} />
+              <AddEnrollment
+                meetId={meetId}
+                onBack={handleBackToEnrollment}
+                setChangeEnrollment={(value) =>
+                  (changeEnrollment.current = value)
+                }
+              />
             </Dialog>
           </>
         )}

--- a/frontend/src/Enrollment/Unenroll.jsx
+++ b/frontend/src/Enrollment/Unenroll.jsx
@@ -1,0 +1,92 @@
+import "../App.css";
+import { Box, Stack, Typography, Divider } from "@mui/material";
+import { SmmApi } from "../SmmApi.jsx";
+import MyButton from "../components/FormElements/MyButton.jsx";
+import AlertBox from "../components/Common/AlertBox.jsx";
+import { useState } from "react";
+
+const Unenroll = ({ athlete, meetId, onBack, setChangeEnrollment }) => {
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  let typeAlert = error ? "error" : "success";
+  let message = error
+    ? "Unable to unenroll athlete, an unexpected error occurred. Please try again!"
+    : `Successfully unenrolled ${athlete.full_name} from the swim meet`;
+
+  const handleUnenroll = async () => {
+    let unenrollmentSuccessful = false;
+    try {
+      await SmmApi.deleteEnrolledAthlete(meetId, { athlete_id: athlete.id });
+      setChangeEnrollment(true);
+      setError(false);
+      unenrollmentSuccessful = true;
+    } catch (error) {
+      setError(true);
+    }
+    setSubmitted(true);
+    console.log(error);
+    setTimeout(() => {
+      if (unenrollmentSuccessful) {
+        onBack();
+      }
+      setSubmitted(false);
+    }, 2000);
+  };
+
+  return (
+    <div
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+      <Stack alignItems="center" justifyContent="space-between">
+        <Stack alignItems="center" justifyContent="space-between">
+          {!submitted && <div style={{ minHeight: "100px" }} />}
+          {submitted && <AlertBox type={typeAlert} message={message} />}
+        </Stack>
+        <Stack className={"whiteBox"}>
+          <Stack>
+            <Box>
+              <Typography
+                variant="subtitle1"
+                color="primary"
+                padding={0.5}
+                align="center"
+                style={{ fontWeight: 600 }}
+              >
+                UNENROLL ATHLETE
+              </Typography>
+            </Box>
+            <Divider sx={{ borderBottomWidth: 3 }} />
+            <Box className={"itemBox"}>
+              <Typography
+                variant="caption"
+                color="primary"
+                padding={0.5}
+                align="center"
+                style={{ fontWeight: 300 }}
+              >
+                Please confirm if you want to unenroll <strong>{athlete.full_name}</strong> from the swim meet, or click Cancel to keep them enrolled.
+              </Typography>
+            </Box>
+          </Stack>
+          <Stack className={"itemBox"}>
+            <MyButton
+              key={"confirm"}
+              label={"Confirm"}
+              onClick={handleUnenroll}
+            />
+            <Box sx={{ marginTop: 2 }} />
+            <MyButton key={"cancel"} label={"Cancel"} onClick={onBack} />
+          </Stack>
+        </Stack>
+      </Stack>
+      <div style={{ minHeight: "100px" }}></div>
+    </div>
+  );
+};
+
+export default Unenroll;

--- a/frontend/src/Enrollment/Unenroll.jsx
+++ b/frontend/src/Enrollment/Unenroll.jsx
@@ -36,12 +36,12 @@ const Unenroll = ({ athlete, meetId, onBack, setChangeEnrollment }) => {
 
   return (
     <div
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
       <Stack alignItems="center" justifyContent="space-between">
         <Stack alignItems="center" justifyContent="space-between">
           {!submitted && <div style={{ minHeight: "100px" }} />}
@@ -69,7 +69,9 @@ const Unenroll = ({ athlete, meetId, onBack, setChangeEnrollment }) => {
                 align="center"
                 style={{ fontWeight: 300 }}
               >
-                Please confirm if you want to unenroll <strong>{athlete.full_name}</strong> from the swim meet, or click Cancel to keep them enrolled.
+                Please confirm if you want to unenroll{" "}
+                <strong>{athlete.full_name}</strong> from the swim meet, or
+                click Cancel to keep them enrolled.
               </Typography>
             </Box>
           </Stack>


### PR DESCRIPTION
### Note: This PR will need to be updated after merging #275 to modify the error message displayed when an athlete cannot be unenrolled because they have already competed.

This pull request addresses Issue #229 and is based on PR #267.

### Implementation

1. frontend/src/Enrollment/Unenroll.jsx

- Displays a component asking whether to confirm or cancel the unenrollment of a selected athlete.
- Includes two buttons:
  - Confirm:
    - Calls `SmmApi.deleteEnrolledAthlete` to unenroll the selected athlete.
    - On success:
      - Displays a success AlertBox.
      - Automatically closes the form after 2 seconds.
    - On failure:
      - Displays an error AlertBox.
      - Keeps the form open; the alert disappears after 2 minutes. 

2. frontend/src/Enrollment/EnrollmentDisplay.jsx

- `handleUnenrollmentClick`:
  - Opens the `Unenroll` component in a pop-up window.
- `handleCancelUnenrollment`:
  - If an athlete has been unenrolled:
    - Clears the search bar (if it’s not already empty).
    - Reloads the enrollment data.
  - Closes the `Unenroll` pop-up window.

UI preview

- Initial view:
![image](https://github.com/user-attachments/assets/fb880530-a97d-46f4-9436-e653a8d711d4)

- Error alert:

![image](https://github.com/user-attachments/assets/751ba547-c9d2-4a20-94e9-237d5201de9b)

- Success alert:

![image](https://github.com/user-attachments/assets/ada9de62-be6b-445a-b5c0-e34abafc754d)

