### PR TITLE
BE - Modify Unenroll Logic 

### DIFF
--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -103,7 +103,11 @@ class MeetEnrolledAthletes(GenericAPIView):
                        },
                    )],
                    summary="Unenroll an Athlete from a specific swim meet",
-                   description="Accepts an athlete ID already enrolled on the swim meet and unenrolls them")
+                   description=(
+        "Removes an athlete from a specific swim meet. "
+        "The athlete must already be enrolled and must not have competed in any events within the meet. "
+        "All associated heat entries will be deleted if eligible."
+    ))
     def patch(self, request, meet_id):
         if not SwimMeet.objects.filter(id=meet_id).exists():
             return Response({'error': 'Swim Meet not found'}, status=status.HTTP_404_NOT_FOUND)

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
 from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiParameter
-from api.models import Enrollment, SwimMeet, Athlete, MeetEvent, Heat
+from api.models import Enrollment, SwimMeet, Athlete, Heat
 from api.serializers.EnrollmentSerializer import UnenrollAthleteSerializer, EnrollAthletesListSerializer
 from api.serializers.AthleteSerializer import AthleteSerializer
 from rest_framework.response import Response


### PR DESCRIPTION
This PR addresses issue #274 

### Implementation

In `backend/api/views/EnrollmentView.py`, the `patch` method was updated as follows:

- Updated the Swagger documentation to reflect the new unenrollment logic.
- The serializer is now validated at the beginning. If validation fails, an error response is returned immediately.
- If validation is successful:
  - Within an atomic transaction, all heats for the specified athlete in the given swim meet are retrieved.
  - If any heat has a `heat_time` that is not `null` and not `300 days (No Show)`, an error is returned stating that the athlete cannot be unenrolled because they have already participated.
  - Otherwise, all associated heats and the athlete's enrollment record are deleted.
### Test

- **Set up**

  -  Created a test swim meet for unenrollment scenarios.
  - Enroll athletes 1,3 and 7 to it

    ![image](https://github.com/user-attachments/assets/60e104f8-bd04-4e7b-8967-1d6bc4250f15)

- **Test Case 1: Unenroll athlete 1 before any event participation**

  - Unenrollment successful.
  ![image](https://github.com/user-attachments/assets/7762be13-6518-4bd5-b498-1b39bbe702bc)
  
  - Verified athlete 1 is no longer enrolled.
  ![image](https://github.com/user-attachments/assets/98ef7bd3-cc04-4fed-abc9-2f3f1c584ab7)

-  **Set up**
    - Re-enroll athlete 1
    -  Add athletes to two events
    ![image](https://github.com/user-attachments/assets/6ff6d16b-b8df-4cca-8b13-984b158a8e29)

- **Test Case 2: Attempt to unenroll athlete 1 (Luis Martinez)**
  - Unenrollment successful.
    ![image](https://github.com/user-attachments/assets/902e9f5b-e6f7-4a8f-99de-2cbea8081590)
  - Heats deleted
    ![image](https://github.com/user-attachments/assets/7aba1bbb-aa2e-434e-9bae-e9b3b17b6e35)

-  **Set up**
    - Athlete 3 (Carlos Rodriguez) has a heat_time in Event 1
    ![image](https://github.com/user-attachments/assets/0b2d778d-fb6c-4198-9a9d-f3187e2c1d90)

- **Test Case 3: Attempt to unenroll athlete 3 (Carlos Rodriguez)**
    - Attempted to unenroll athlete 3. Expected behavior: Unenrollment fails — athlete has participated.
    ![image](https://github.com/user-attachments/assets/d65cf672-db96-4c5a-9d41-492b7821de74)

-  **Set up**
    - Athlete 7 (Andrew Chen) has a heat_time in Event 1 and No Show in Event 2
    ![image](https://github.com/user-attachments/assets/f7d20cc9-eebb-4848-b9c7-62b97b56efab)
- **Test Case 4: Attempt to unenroll athlete 7 (Andrew Chen)**
    - Attempted to unenroll athlete 7. Expected behavior: Unenrollment fails — athlete has participated.
    ![image](https://github.com/user-attachments/assets/362106b8-4293-4921-b09f-d6182b92f075)

-  **Set up**
    - Changed athlete 7’s heat_time in Event 1 to NS
    ![image](https://github.com/user-attachments/assets/0b7f87ce-8fa7-484c-bd08-e144cb1e2ad6)

- **Test Case 5: Attempt to unenroll athlete 7 (Andrew Chen)**
    - Attempted to unenroll athlete 7. Expected behavior: Unenrollment succeeds — all heat times are either null or NS.
    ![image](https://github.com/user-attachments/assets/fd20aa0e-57b4-4953-90f3-e1a5a968bf0c)

