### PR TITLE
BE- Athlete Unenroll Check

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -19,7 +19,7 @@ from api.views.EventResultView import EventResultView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 from api.views.download.DownloadResults import DownloadEventResults
 from api.views.download.DownloadResults import DownloadEventResultsForSwimMeet
-from api.views.EnrollmentView import MeetEnrolledAthletes, MeetUnenrolledAthletes, Unenrollability
+from api.views.EnrollmentView import MeetEnrolledAthletes, MeetUnenrolledAthletes, MeetAthleteUnenrollCheck
 
 
 from rest_framework.routers import SimpleRouter
@@ -68,8 +68,8 @@ urlpatterns = [
          MeetEnrolledAthletes.as_view(), name='meet-enroll'),
     path('meet_unenrolled/<int:meet_id>/',
          MeetUnenrolledAthletes.as_view(), name='meet-unenrolled-athletes'),
-     path('meet_unenrolled/<int:meet_id>/<int:athlete_id>/',
-         Unenrollability.as_view(), name='unenrollability-athletes'),
+    path('meet_unenrolled/<int:meet_id>/<int:athlete_id>/',
+         MeetAthleteUnenrollCheck.as_view(), name='unenroll-check'),
 
 ]
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -19,7 +19,7 @@ from api.views.EventResultView import EventResultView
 from api.views.download.DownloadHeats import DownloadAllHeatsByEvent, DownloadAllHeatsByMeet
 from api.views.download.DownloadResults import DownloadEventResults
 from api.views.download.DownloadResults import DownloadEventResultsForSwimMeet
-from api.views.EnrollmentView import MeetEnrolledAthletes, MeetUnenrolledAthletes
+from api.views.EnrollmentView import MeetEnrolledAthletes, MeetUnenrolledAthletes, Unenrollability
 
 
 from rest_framework.routers import SimpleRouter
@@ -68,6 +68,8 @@ urlpatterns = [
          MeetEnrolledAthletes.as_view(), name='meet-enroll'),
     path('meet_unenrolled/<int:meet_id>/',
          MeetUnenrolledAthletes.as_view(), name='meet-unenrolled-athletes'),
+     path('meet_unenrolled/<int:meet_id>/<int:athlete_id>/',
+         Unenrollability.as_view(), name='unenrollability-athletes'),
 
 ]
 

--- a/backend/api/views/EnrollmentView.py
+++ b/backend/api/views/EnrollmentView.py
@@ -164,7 +164,7 @@ class MeetUnenrolledAthletes(GenericAPIView):
 
 
 @extend_schema(tags=['Swim Meet - Enrollment'])
-class Unenrollability(GenericAPIView):
+class MeetAthleteUnenrollCheck(GenericAPIView):
 
     @extend_schema(methods=['GET'],
                    summary="Check if an athlete can be unenrolled from a swim meet.",


### PR DESCRIPTION
This PR address issue #277

### Implementation

1.  backend/api/views/EnrollmentView.py

- Created a new class `MeetAthleteUnenrollCheck`, inheriting from `GenericAPIView`.
- Implements a `GET` method that accepts `meet_id` and `athlete_id` as path parameters.
- Performs the following validations:
  - Checks that the swim meet exists.
  - Checks that the athlete exists.
  - Verifies that the athlete is enrolled in the specified swim meet.

- Retrieves all heats associated with the athlete for the given swim meet.
- Filters out heats where the `heat_time` is null or marked as NS.
- If any valid `heat_time` exists, returns `False` (athlete cannot be unenrolled).
- Otherwise, returns `True` (athlete can be unenrolled).


2. backend/api/urls.py

- Added a new endpoint:
  - meet_unenroll_check/<int:meet_id>/<int:athlete_id>/ connected to MeetAthleteUnenrollCheck.

### Tests

1. Initial Enrollment

- Created a new swim meet and enrolled an athlete.
- Called the unenroll check endpoint.

✅ Received True (expected — athlete has no recorded heat time).

2.  Assigned Athlete to a Heat (No Time Yet)

- Created an event and added the athlete to a heat (without setting a heat time).
- Called the unenroll check endpoint.

✅ Received True (expected — no valid heat time yet).

3. Set a Valid Heat Time

- Assigned a valid heat time to the athlete in the heat.
- Called the unenroll check endpoint.

✅ Received False (expected — athlete has a recorded time and cannot be unenrolled).

4. Set Heat Time to 'NS'

- Updated the athlete's heat time to 'NS'.
- Called the unenroll check endpoint.

✅ Received True (expected — 'NS' is treated as no valid time).

5. Added the athlete to a new event.

- Created an event and added the athlete to a heat (without setting a heat time).
- Called the unenroll check endpoint.

✅ Received True (expected — athlete has a NS and a no recorded heat time).

6.  Set a Valid Heat Time

- Assigned a valid heat time to the athlete in the new heat.
- Called the unenroll check endpoint.

✅ Received False (expected — athlete has a recorded time and a NS, cannot be unenrolled).
