### PR TITLE
BUG - SwimMeetDisplay Refresh after Creation

### DIFF
--- a/frontend/src/SwimMeet/AddSwimMeet.jsx
+++ b/frontend/src/SwimMeet/AddSwimMeet.jsx
@@ -9,7 +9,11 @@ import AlertBox from "../components/Common/AlertBox.jsx";
 import { SmmApi } from "../SmmApi.jsx";
 import SwimMeetForm from "./SwimMeetForm.jsx";
 
-const AddSwimMeet = ({ onCancel }) => {
+const AddSwimMeet = ({
+  onCancel,
+  setLastSwimMeetCreated,
+  setNumNewSwimMeets
+}) => {
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
   const [errorOnLoading, setErrorOnLoading] = useState(false);
@@ -112,7 +116,6 @@ const AddSwimMeet = ({ onCancel }) => {
   let actionButtons = error ? [] : actionButtonsSuccess;
 
   const submission = async (data) => {
-    console.log(data);
     const time = dayjs(data.time).format("HH:mm");
     //To get an error use this date
     //const date = dayjs(data.date);
@@ -130,6 +133,8 @@ const AddSwimMeet = ({ onCancel }) => {
         date: dayjs(response.data.date).format("MM/DD/YYYY"),
       };
       setLastSwimMeetData(formattedResponse);
+      setNumNewSwimMeets(1);
+      setLastSwimMeetCreated(response.data.id);
     } catch (error) {
       setError(true);
     }

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -64,7 +64,6 @@ const SwimMeetDisplay = () => {
     if (searchBarRef.current) {
       searchBarRef.current.clearSearch();
     }
-    setSearchPar("");
     setIsFormOpen(true);
   };
 
@@ -96,7 +95,9 @@ const SwimMeetDisplay = () => {
   };
 
   const handleRankingClick = () => {
-    console.log("Ranking ...");
+    navigate(`/swim-meets/${data[id].id}/events`, {
+      state: { meetData: data[id], showRanking: true },
+    });
   };
 
   const actions = [

--- a/frontend/src/SwimMeet/SwimMeetDisplay.jsx
+++ b/frontend/src/SwimMeet/SwimMeetDisplay.jsx
@@ -95,9 +95,6 @@ const SwimMeetDisplay = () => {
   };
 
   const handleRankingClick = () => {
-    navigate(`/swim-meets/${data[id].id}/events`, {
-      state: { meetData: data[id], showRanking: true },
-    });
   };
 
   const actions = [


### PR DESCRIPTION
This PR addresses issue #276 

### Implementation

1. frontend/src/SwimMeet/AddSwimMeet.jsx
- New Props Added:
  - `setLastSwimMeetCreated`
    - Updates the `lastSwimMeetCreated` ref with the ID of the most recently created swim meet.
  - `setNumNewSwimMeets`
    - Increments the `numNewSwimMeets` ref in `SwimMeetDisplay` each time a swim meet is successfully created.

2. frontend/src/SwimMeet/SwimMeetDisplay.jsx

- New Refs Added:
  - `lastCreatedSwimMeetId`:
    - Initially set to null.
    - Passed to `AddSwimMeet` to keep track of the last created swim meet’s ID.
  -` numSwimMeetsCreated`:
    - Initially set to 0.
    - Tracks the number of newly created swim meets.

- Updated `handleAddNew` Function:
  -Clears the search bar (if needed) before opening the `AddSwimMeet` form.
- Updated `handleCancelAddSwimMeet` Function:
  - If a swim meet was created, triggers a function to find its position in the dataset.
- Added `refreshDataForLastCreatedSwimMeet` Function:
  -Fetches updated swim meet data from the backend.
  - Finds the index of the last created swim meet.
  - Calculates which page it falls on.
  - Updates the view to show the correct page.
  - Resets `lastCreatedSwimMeetId` and `numSwimMeetsCreated` after the refresh is complete.