### PR TITLE
BUG - Num_lanes on a Swim Meet

### DIFF
--- a/backend/api/views/HeatView.py
+++ b/backend/api/views/HeatView.py
@@ -24,9 +24,9 @@ class HeatBatchView(APIView):
         # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
+            num_lanes = swim_meet_instance.num_lanes
         except:
-            return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response({'error': 'Number of lanes not found for the swim meet.'}, status=status.HTTP_404_NOT_FOUND)
 
         max_num_heat = event_instance.total_num_heats
 
@@ -80,10 +80,10 @@ class HeatBatchView(APIView):
         # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
+            num_lanes = swim_meet_instance.num_lanes
 
         except:
-            return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response({'error': 'Number of lanes not found for the swim meet.'}, status=status.HTTP_404_NOT_FOUND)
 
         # Get group_id
         try:
@@ -148,9 +148,9 @@ class HeatDetailView(APIView):
         # Get number of lanes on the event
         try:
             swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
+            num_lanes = swim_meet_instance.num_lanes
         except:
-            return Response({'error': 'Number of lanes not found for the swim meet site.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response({'error': 'Number of lanes not found for the swim meet.'}, status=status.HTTP_404_NOT_FOUND)
 
         # Get number of heats on the event
         max_num_heat = event_instance.total_num_heats

--- a/backend/api/views/LaneView.py
+++ b/backend/api/views/LaneView.py
@@ -21,7 +21,7 @@ class LaneBatchView(APIView):
         # Get num_lanes
         try:
             swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
+            num_lanes = swim_meet_instance.num_lanes
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
 
@@ -77,7 +77,7 @@ class LaneDetailView(APIView):
         # Get number of lanes on the event
         try:
             swim_meet_instance = event_instance.swim_meet
-            num_lanes = swim_meet_instance.site.num_lanes
+            num_lanes = swim_meet_instance.num_lanes
         except:
             return Response({'error': 'Not able to retrieve number of lanes'}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
This PR address issue #282. Ensures that heat and lane calculations use the correct `num_lanes` value defined on the Swim Meet model, as intended after the changes introduced in PR #233.

### Implementation

- Updated `num_lanes` retrieval in the following files: 
  - `backend/api/views/HeatView.py`
  - `backend/api/views/LaneView.py`
- Replaced `swim_meet_instance.site.num_lanes` with `swim_meet_instance.num_lanes`.

