### PR TITLE
FE - Navigate Between Heats and Results 

### DIFF
--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -22,7 +22,7 @@ const EventDetails = ({
   onNext,
   onGenerate,
   onDownload,
-  onRancking,
+  onRanking,
   disablePrevious,
   disableNext,
 }) => {
@@ -73,9 +73,9 @@ const EventDetails = ({
       onClick: onBack,
     },
     {
-      label: "Go to results",
+      label: "Show Results",
       icon: <RankingIcon />,
-      onClick: onRancking,
+      onClick: onRanking,
     },
     {
       label: "Download Details",

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -76,6 +76,7 @@ const EventDetails = ({
       label: "Show Results",
       icon: <RankingIcon />,
       onClick: onRanking,
+      disabled: numHeats === 0,
     },
     {
       label: "Download Details",

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -2,6 +2,7 @@ import {
   ContentPaste as BackIcon,
   Build as BuildIcon,
   Download as DownloadIcon,
+  EmojiEvents as RankingIcon,
 } from "@mui/icons-material";
 import { CircularProgress, Stack } from "@mui/material";
 import React, { useEffect, useState } from "react";
@@ -21,6 +22,7 @@ const EventDetails = ({
   onNext,
   onGenerate,
   onDownload,
+  onRancking,
   disablePrevious,
   disableNext,
 }) => {
@@ -69,6 +71,11 @@ const EventDetails = ({
       label: "Back to events",
       icon: <BackIcon />,
       onClick: onBack,
+    },
+    {
+      label: "Go to results",
+      icon: <RankingIcon />,
+      onClick: onRancking,
     },
     {
       label: "Download Details",

--- a/frontend/src/Event/EventDetails.jsx
+++ b/frontend/src/Event/EventDetails.jsx
@@ -73,7 +73,7 @@ const EventDetails = ({
       onClick: onBack,
     },
     {
-      label: "Show Results",
+      label: "Show Ranking",
       icon: <RankingIcon />,
       onClick: onRanking,
       disabled: numHeats === 0,

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -70,7 +70,7 @@ const MeetEventDisplay = () => {
     setView("generate");
   };
 
-  const handleDetailsClick = (id) => {
+  const handleHeatsClick = (id) => {
     if (selectedEventIndex === null) {
       setSelectedEventIndex(Number(id));
     }
@@ -132,7 +132,7 @@ const MeetEventDisplay = () => {
     {
       name: "Heats Details",
       icon: <HeatIcon />,
-      onClick: handleDetailsClick,
+      onClick: handleHeatsClick,
       tip: "Go to Heats",
       visible: (row) => row.original.total_num_heats > 0,
     },
@@ -358,7 +358,7 @@ const MeetEventDisplay = () => {
             onNext={handleNextEvent}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
-            onHeats={handleDetailsClick}
+            onHeats={handleHeatsClick}
           />
         );
       default:

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -329,7 +329,7 @@ const MeetEventDisplay = () => {
             onNext={handleNextEvent}
             onGenerate={handleGenerateButtonOnEventDetails}
             onDownload={handleDownloadDetailsForEvent}
-            onRancking={handleRankingClick}
+            onRanking={handleRankingClick}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
           />

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -71,7 +71,9 @@ const MeetEventDisplay = () => {
   };
 
   const handleDetailsClick = (id) => {
-    setSelectedEventIndex(Number(id));
+    if (selectedEventIndex === null) {
+      setSelectedEventIndex(Number(id));
+    }
     setView("details");
   };
 
@@ -356,6 +358,7 @@ const MeetEventDisplay = () => {
             onNext={handleNextEvent}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
+            onHeats={handleDetailsClick}
           />
         );
       default:

--- a/frontend/src/Event/MeetEventDisplay.jsx
+++ b/frontend/src/Event/MeetEventDisplay.jsx
@@ -80,7 +80,9 @@ const MeetEventDisplay = () => {
   };
 
   const handleRankingClick = (id) => {
-    setSelectedEventIndex(Number(id));
+    if (selectedEventIndex === null) {
+      setSelectedEventIndex(Number(id));
+    }
     setView("results");
   };
 
@@ -327,6 +329,7 @@ const MeetEventDisplay = () => {
             onNext={handleNextEvent}
             onGenerate={handleGenerateButtonOnEventDetails}
             onDownload={handleDownloadDetailsForEvent}
+            onRancking={handleRankingClick}
             disablePrevious={isFirstEvent}
             disableNext={isLastEvent}
           />

--- a/frontend/src/Results/EventResults.jsx
+++ b/frontend/src/Results/EventResults.jsx
@@ -1,6 +1,7 @@
 import {
   ContentPaste as BackIcon,
   Download as DownloadIcon,
+  FormatAlignCenter as HeatIcon,
 } from "@mui/icons-material";
 import { CircularProgress, Stack } from "@mui/material";
 import React, { useEffect, useState } from "react";
@@ -83,6 +84,7 @@ const EventResults = ({
   onNext,
   disablePrevious,
   disableNext,
+  onHeats,
 }) => {
   const [resultsData, setResultsData] = useState({ main: [] });
   const [hasResults, setHasResults] = useState(null);
@@ -277,6 +279,11 @@ const EventResults = ({
       label: "Back to events",
       icon: <BackIcon />,
       onClick: onBack,
+    },
+    {
+      label: "Show Heats",
+      icon: <HeatIcon />,
+      onClick: onHeats,
     },
     {
       label: "Download Results",


### PR DESCRIPTION
This PR address issue #281 

### Implementation

1. **frontend/src/Event/EventDetails.jsx**

- Added `onRanking` as a prop, passed from `MeetEventDisplay`. This function sets the view to `results`.

- Added a **Show Ranking** button:
  - Navigates to the ranking view for the current event.
  - Disabled if the event does not have heats (same condition as the download button).

2. frontend/src/Results/EventResults.jsx

- Added `onHeats` as a prop, also from `MeetEventDisplay`. This function sets the view to display the heats component.
- Added a **Show Heats** button:
  - Navigates back to the heats view for the current event.

3. frontend/src/Event/MeetEventDisplay.jsx

- Renamed `handleDetailsClick` to `handleHeatsClick` for clarity.
- Refactored `handleHeatsClick`:
  - If `selectedEventIndex` is `null`, the function is being called directly from `MeetEventDisplay` (i.e., a row was clicked in the table). In that case, we only assign the row's ID.
- Refactored `handleRankingClick`:
  - Same logic applies: update `selectedEventIndex` only if it’s null.

### UI Preview

- **Show Ranking** button when viewing heats

![image](https://github.com/user-attachments/assets/3f48ca59-0113-4043-93a0-63ea6b08a7c7)

- **Show Heats** button when viewing the ranking:

![image](https://github.com/user-attachments/assets/fa5ad37f-0558-45c6-b6ac-75f6178e9110)

