### PR TITLE
FE- Button to Navigate from Enrollment to Events and Athlete Info Columns 

### DIFF
--- a/frontend/src/Enrollment/AddEnrollment.jsx
+++ b/frontend/src/Enrollment/AddEnrollment.jsx
@@ -28,12 +28,32 @@ const availableColumns = [
     header: "Available Athletes",
     size: 150,
   },
+  {
+    accessorKey: "gender_display",
+    header: "Gender",
+    size: 150,
+  },
+  {
+    accessorKey: "age",
+    header: "Age",
+    size: 150,
+  },
 ];
 
 const selectedColumns = [
   {
     accessorKey: "full_name",
     header: "Athletes to Enroll",
+    size: 150,
+  },
+  {
+    accessorKey: "gender_display",
+    header: "Gender",
+    size: 150,
+  },
+  {
+    accessorKey: "age",
+    header: "Age",
     size: 150,
   },
 ];
@@ -93,8 +113,8 @@ const AddEnrollment = ({ meetId, onBack, setChangeEnrollment }) => {
       const response = await SmmApi.createEnrollment(meetId, {
         athlete_ids: athleteIds,
       });
-      const num_added= athleteIds.length;
-      const athleteNoun = num_added === 1 ? "athlete": "athletes";
+      const num_added = athleteIds.length;
+      const athleteNoun = num_added === 1 ? "athlete" : "athletes";
       setErrorCreateEnrollment(
         `Successfully enrolled ${num_added} ${athleteNoun} in the swim meet.`
       );

--- a/frontend/src/Enrollment/EnrollmentDisplay.jsx
+++ b/frontend/src/Enrollment/EnrollmentDisplay.jsx
@@ -1,6 +1,7 @@
 import {
   Add as AddIcon,
   PersonRemove as UnenrollIcon,
+  Build as BuildIcon,
 } from "@mui/icons-material";
 import { SmmApi } from "../SmmApi";
 import AlertBox from "../components/Common/AlertBox.jsx";
@@ -13,7 +14,7 @@ import AddEnrollment from "./AddEnrollment.jsx";
 import Unenroll from "./Unenroll.jsx";
 import { CircularProgress, Box, Stack, Dialog } from "@mui/material";
 import { useEffect, useState, useRef } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams, useNavigate } from "react-router-dom";
 
 const columns = [
   {
@@ -36,6 +37,7 @@ const columns = [
 const EnrollmentDisplay = () => {
   const { meetId } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const meetData = location.state?.meetData;
   //Controls the data
   const [enrollmentData, setEnrollmentData] = useState([]);
@@ -67,7 +69,12 @@ const EnrollmentDisplay = () => {
   const handleAddEnrollment = () => {
     setIsAddEnrollmentOpen(true);
   };
-
+  const handleGoToEvents = () => {
+    console.log("Go To Events");
+    navigate(`/swim-meets/${meetId}/events`, {
+      state: { meetData: meetData },
+    });
+  };
   const handleBackToEnrollment = () => {
     if (!changeEnrollment.current) {
       setIsAddEnrollmentOpen(false);
@@ -153,11 +160,24 @@ const EnrollmentDisplay = () => {
           alignItems="center"
           justifyContent="space-between"
         >
-          <Box sx={{ marginLeft: 5 }}>
-            <MyButton label={"Enroll"} onClick={handleAddEnrollment}>
-              <AddIcon />
-            </MyButton>
-          </Box>
+          <Stack
+            sx={{ marginLeft: 5 }}
+            direction="row"
+            alignItems="center"
+            spacing={2}
+          >
+            <Box sx={{ marginLeft: 5 }}>
+              <MyButton label={"Enroll"} onClick={handleAddEnrollment}>
+                <AddIcon />
+              </MyButton>
+            </Box>
+            <Box sx={{ marginLeft: 5 }}>
+              <MyButton label={"Go To Events"} onClick={handleGoToEvents}>
+                <BuildIcon />
+              </MyButton>
+            </Box>
+          </Stack>
+
           <Box className={"searchBox"} sx={{ marginRight: 5 }}>
             <SearchBar
               ref={searchBarRef}

--- a/frontend/src/Enrollment/EnrollmentDisplay.jsx
+++ b/frontend/src/Enrollment/EnrollmentDisplay.jsx
@@ -1,7 +1,7 @@
 import {
   Add as AddIcon,
   PersonRemove as UnenrollIcon,
-  Build as BuildIcon,
+  ContentPaste as DetailsIcon,
 } from "@mui/icons-material";
 import { SmmApi } from "../SmmApi";
 import AlertBox from "../components/Common/AlertBox.jsx";
@@ -173,7 +173,7 @@ const EnrollmentDisplay = () => {
             </Box>
             <Box sx={{ marginLeft: 5 }}>
               <MyButton label={"Go To Events"} onClick={handleGoToEvents}>
-                <BuildIcon />
+                <DetailsIcon />
               </MyButton>
             </Box>
           </Stack>


### PR DESCRIPTION
This PR address issue #273

### Implementation

1. **frontend/src/Enrollment/EnrollmentDisplay.jsx**

- Added a **Go To Events** button to navigate to the events view (`MeetEventDisplay`) for the current swim meet.

2. **frontend/src/Enrollment/AddEnrollment.jsx**

- Added Gender and Age columns to `availableColumns` and `selectedColumns` in order to show the athlete's gender and age information in the select table components when enrolling a new athlete.


### UI Preview

- **Go To Events** button when displaying the Enrollment.

<img width="1541" alt="Screenshot 2025-06-04 at 6 56 51 PM" src="https://github.com/user-attachments/assets/b7ad2e78-960c-43c5-ae10-64c0dc337149" />

- **Gender**  and **Age** columns in the select tables when enrolling athletes:

<img width="1292" alt="Screenshot 2025-06-04 at 6 56 36 PM" src="https://github.com/user-attachments/assets/96e70585-d9b7-43fa-a8a4-47b066b739af" />

